### PR TITLE
Optimize powf more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ nalgebra = "0.31.1"
 num-traits = "0.2.15"
 paste = "1.0.9"
 v_frame = "0.3.0"
-wide = { git = "https://github.com/shssoichiro/wide", branch = "fast-cast-fns" }
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -73,34 +73,9 @@ pub fn cbrtf(x: f32) -> f32 {
     t as f32
 }
 
-#[inline(always)]
-fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
-    x.mul_add(poly4(x, c1, c2, c3, c4, c5), c0)
-}
-
-#[inline(always)]
-fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
-    x.mul_add(poly3(x, c1, c2, c3, c4), c0)
-}
-
-#[inline(always)]
-fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
-    x.mul_add(poly2(x, c1, c2, c3), c0)
-}
-
-#[inline(always)]
-fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
-    x.mul_add(poly1(x, c1, c2), c0)
-}
-
-#[inline(always)]
-fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
-    x.mul_add(poly0(x, c1), c0)
-}
-
-#[inline(always)]
-const fn poly0(_x: f32, c0: f32) -> f32 {
-    c0
+// Based on https://jrfonseca.blogspot.com/2008/09/fast-sse2-pow-tables-or-polynomials.html
+pub fn powf(x: f32, y: f32) -> f32 {
+    exp2(log2(x) * y)
 }
 
 fn exp2(x: f32) -> f32 {
@@ -148,6 +123,32 @@ fn log2(x: f32) -> f32 {
     polynomial + exp
 }
 
-pub fn powf(x: f32, y: f32) -> f32 {
-    exp2(log2(x) * y)
+#[inline(always)]
+fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
+    x.mul_add(poly4(x, c1, c2, c3, c4, c5), c0)
+}
+
+#[inline(always)]
+fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
+    x.mul_add(poly3(x, c1, c2, c3, c4), c0)
+}
+
+#[inline(always)]
+fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
+    x.mul_add(poly2(x, c1, c2, c3), c0)
+}
+
+#[inline(always)]
+fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
+    x.mul_add(poly1(x, c1, c2), c0)
+}
+
+#[inline(always)]
+fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
+    x.mul_add(poly0(x, c1), c0)
+}
+
+#[inline(always)]
+const fn poly0(_x: f32, c0: f32) -> f32 {
+    c0
 }

--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -18,9 +18,6 @@
  */
 
 use core::f32;
-use std::mem::transmute;
-
-use wide::{f32x4, i32x4};
 
 const B1: u32 = 709_958_130; /* B1 = (127-127.0/3-0.03306235651)*2**23 */
 const B2: u32 = 642_849_266; /* B2 = (127-127.0/3-24/3-0.03306235651)*2**23 */
@@ -36,7 +33,7 @@ pub fn cbrtf(x: f32) -> f32 {
     let mut ui: u32 = x.to_bits();
     let mut hx: u32 = ui & 0x7fff_ffff;
 
-    if hx >= 0x7f80_0000 {
+    if hx >= 0x7F80_0000 {
         /* cbrt(NaN,INF) is itself */
         return x + x;
     }
@@ -48,7 +45,7 @@ pub fn cbrtf(x: f32) -> f32 {
             return x; /* cbrt(+-0) is itself */
         }
         ui = (x * x1p24).to_bits();
-        hx = ui & 0x7fff_ffff;
+        hx = ui & 0x7FFF_FFFF;
         hx = hx / 3 + B2;
     } else {
         hx = hx / 3 + B1;
@@ -76,81 +73,81 @@ pub fn cbrtf(x: f32) -> f32 {
     t as f32
 }
 
-// Credit to https://jrfonseca.blogspot.com/2008/09/fast-sse2-pow-tables-or-polynomials.html
-pub fn powf_wide(x: f32x4, pow: f32) -> f32x4 {
-    exp2_wide(log2_wide(x) * pow)
+#[inline(always)]
+fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
+    x.mul_add(poly4(x, c1, c2, c3, c4, c5), c0)
 }
 
-fn exp2_wide(x: f32x4) -> f32x4 {
-    // Uses a polynomial degree of 3 to fast approximate exp2
-    let x = x
-        .fast_min(f32x4::from(129.00000f32))
-        .fast_max(f32x4::from(-126.99999f32));
-    let ipart = (x - 0.5f32).to_i32x4_round_fast();
-    let fpart = x - ipart.to_f32x4();
-    // SAFETY: Types are the same size
-    let expipart: f32x4 = unsafe { transmute((ipart + i32x4::from(127i32)) << 23i32) };
-    let expfpart = poly3(
+#[inline(always)]
+fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
+    x.mul_add(poly3(x, c1, c2, c3, c4), c0)
+}
+
+#[inline(always)]
+fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
+    x.mul_add(poly2(x, c1, c2, c3), c0)
+}
+
+#[inline(always)]
+fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
+    x.mul_add(poly1(x, c1, c2), c0)
+}
+
+#[inline(always)]
+fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
+    x.mul_add(poly0(x, c1), c0)
+}
+
+#[inline(always)]
+const fn poly0(_x: f32, c0: f32) -> f32 {
+    c0
+}
+
+fn exp2(x: f32) -> f32 {
+    let x = x.clamp(-126.99999, 129.0);
+
+    // SAFETY: Value is clamped
+    let ipart: i32 = unsafe { (x - 0.5).to_int_unchecked() };
+    let fpart = x - ipart as f32;
+
+    let expi = f32::from_bits(((ipart + 127_i32) << 23_i32) as u32);
+    let expf = poly5(
         fpart,
-        9.999_252e-1_f32,
-        6.958_335_6e-1_f32,
-        2.260_671_6e-1_f32,
-        7.802_452e-2_f32,
+        9.999_999_4E-1,
+        6.931_531E-1,
+        2.401_536_1E-1,
+        5.582_631_8E-2,
+        8.989_34E-3,
+        1.877_576_7E-3,
     );
 
-    expipart * expfpart
+    expi * expf
 }
 
-#[allow(clippy::many_single_char_names)]
-fn log2_wide(x: f32x4) -> f32x4 {
-    // Uses a polynomial degree of 5 to fast approximate log2
-    let exp = i32x4::from(0x7F80_0000_i32);
-    let mant = i32x4::from(0x007F_FFFF_i32);
-    // SAFETY: Types are the same size
-    let i: i32x4 = unsafe { transmute(x) };
-    let e = (((i & exp) >> 23i32) - 127i32).to_f32x4();
-    // SAFETY: Types are the same size
-    let m_temp: f32x4 = unsafe { transmute(i & mant) };
-    let m = m_temp | f32x4::ONE;
-    let p = poly5(
-        m,
-        3.115_79_f32,
-        -3.324_199_f32,
-        2.598_845_2_f32,
-        -1.231_530_3_f32,
-        3.182_133_7e-1_f32,
-        -3.443_600_6e-2_f32,
+fn log2(x: f32) -> f32 {
+    let expmask = 0x7F80_0000_i32;
+    let mantmask = 0x007F_FFFF_i32;
+
+    let one_bits = 1_f32.to_bits() as i32;
+    let x_bits = x.to_bits() as i32;
+    let exp = (((x_bits & expmask) >> 23_i32) - 127_i32) as f32;
+
+    let mant = f32::from_bits(((x_bits & mantmask) | one_bits) as u32);
+
+    let polynomial = poly5(
+        mant,
+        3.115_79,
+        -3.324_199,
+        2.598_845_2,
+        -1.231_530_3,
+        3.182_133_7E-1,
+        -3.443_600_6E-2,
     );
-    let p = p * (m - f32x4::ONE);
-    p + e
+    let polynomial = polynomial * (mant - 1.0);
+
+    polynomial + exp
 }
 
-#[inline(always)]
-fn poly0(_x: f32x4, c0: f32) -> f32x4 {
-    f32x4::from(c0)
-}
-
-#[inline(always)]
-fn poly1(x: f32x4, c0: f32, c1: f32) -> f32x4 {
-    poly0(x, c1).mul_add(x, f32x4::from(c0))
-}
-
-#[inline(always)]
-fn poly2(x: f32x4, c0: f32, c1: f32, c2: f32) -> f32x4 {
-    poly1(x, c1, c2).mul_add(x, f32x4::from(c0))
-}
-
-#[inline(always)]
-fn poly3(x: f32x4, c0: f32, c1: f32, c2: f32, c3: f32) -> f32x4 {
-    poly2(x, c1, c2, c3).mul_add(x, f32x4::from(c0))
-}
-
-#[inline(always)]
-fn poly4(x: f32x4, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32x4 {
-    poly3(x, c1, c2, c3, c4).mul_add(x, f32x4::from(c0))
-}
-
-#[inline(always)]
-fn poly5(x: f32x4, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32x4 {
-    poly4(x, c1, c2, c3, c4, c5).mul_add(x, f32x4::from(c0))
+pub fn powf(x: f32, y: f32) -> f32 {
+    exp2(log2(x) * y)
 }


### PR DESCRIPTION
Basic idea: Use a scalar `powf` implementation and let the compiler handle it. Seems to auto-vectorize up to AVX or AVX2 without problem (no AVX-512).