### PR TITLE
Optimize `cbrtf` by removing checks for non-normal floats

### DIFF
--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -30,7 +30,7 @@ pub fn cbrtf(x: f32) -> f32 {
     let mut r: f64;
     let mut t: f64;
     let mut ui: u32 = x.to_bits();
-    let mut hx: u32 = ui & 0x7fff_ffff;
+    let mut hx: u32 = ui & 0x7FFF_FFFF;
 
     hx = hx / 3 + B1;
     ui &= 0x8000_0000;

--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -20,36 +20,19 @@
 use core::f32;
 
 const B1: u32 = 709_958_130; /* B1 = (127-127.0/3-0.03306235651)*2**23 */
-const B2: u32 = 642_849_266; /* B2 = (127-127.0/3-24/3-0.03306235651)*2**23 */
 
 /// Cube root (f32)
 ///
 /// Computes the cube root of the argument.
+/// The argument must be normal (not NaN, +/-INF or subnormal).
+/// This is required for optimization purposes.
 pub fn cbrtf(x: f32) -> f32 {
-    let x1p24 = f32::from_bits(0x4b80_0000); // 0x1p24f === 2 ^ 24
-
     let mut r: f64;
     let mut t: f64;
     let mut ui: u32 = x.to_bits();
     let mut hx: u32 = ui & 0x7fff_ffff;
 
-    if hx >= 0x7F80_0000 {
-        /* cbrt(NaN,INF) is itself */
-        return x + x;
-    }
-
-    /* rough cbrt to 5 bits */
-    if hx < 0x0080_0000 {
-        /* zero or subnormal? */
-        if hx == 0 {
-            return x; /* cbrt(+-0) is itself */
-        }
-        ui = (x * x1p24).to_bits();
-        hx = ui & 0x7FFF_FFFF;
-        hx = hx / 3 + B2;
-    } else {
-        hx = hx / 3 + B1;
-    }
+    hx = hx / 3 + B1;
     ui &= 0x8000_0000;
     ui |= hx;
 


### PR DESCRIPTION
This code removes checks for `NaN`, +/-`INF` and subnormal numbers. This should be a safe assumption to make for all realistic input values. This presumably leads to more optimization due to less branching and maybe even auto-vectorization, but i honestly haven't checked. It's faster either way.

I originally wanted to refactor the code too, but I don't think that's necessary.

Benches on my machine (compared to main, after #2):

```
yuv 8-bit 4:4:4 full to xyb
time:   [1.0548 ms 1.0589 ms 1.0625 ms]
change: [-15.318% -15.092% -14.888%] (p = 0.00 < 0.05)

yuv 8-bit 4:2:0 full to xyb
time:   [1.0718 ms 1.0723 ms 1.0728 ms]
change: [-14.961% -14.538% -14.096%] (p = 0.00 < 0.05)

yuv 8-bit 4:2:0 limited to xyb
time:   [1.0900 ms 1.0960 ms 1.1007 ms]
change: [-19.420% -18.778% -18.137%] (p = 0.00 < 0.05)

yuv 10-bit 4:4:4 full to xyb
time:   [2.1877 ms 2.1933 ms 2.1987 ms]
change: [-8.8755% -8.6175% -8.3740%] (p = 0.00 < 0.05)

yuv 10-bit 4:2:0 full to xyb
time:   [2.1953 ms 2.2000 ms 2.2041 ms]
change: [-8.2624% -8.0527% -7.8794%] (p = 0.00 < 0.05)

yuv 10-bit 4:2:0 limited to xyb
time:   [2.2079 ms 2.2098 ms 2.2117 ms]
change: [-7.7100% -7.6196% -7.5257%] (p = 0.00 < 0.05)
```

And `-C target-cpu=native`:

```
yuv 8-bit 4:4:4 full to xyb
time:   [1.0637 ms 1.0719 ms 1.0785 ms]
change: [-17.156% -16.642% -16.098%] (p = 0.00 < 0.05)

yuv 8-bit 4:2:0 full to xyb
time:   [1.0291 ms 1.0320 ms 1.0352 ms]
change: [-19.189% -19.058% -18.899%] (p = 0.00 < 0.05)

yuv 8-bit 4:2:0 limited to xyb
time:   [1.0234 ms 1.0271 ms 1.0314 ms]
change: [-18.451% -18.066% -17.681%] (p = 0.00 < 0.05)

yuv 10-bit 4:4:4 full to xyb
time:   [2.1880 ms 2.1902 ms 2.1930 ms]
change: [-4.1505% -4.0319% -3.9035%] (p = 0.00 < 0.05)

yuv 10-bit 4:2:0 full to xyb
time:   [2.1252 ms 2.1261 ms 2.1270 ms]
change: [-10.990% -10.809% -10.607%] (p = 0.00 < 0.05)

yuv 10-bit 4:2:0 limited to xyb
time:   [2.0910 ms 2.0930 ms 2.0955 ms]
change: [-10.939% -10.659% -10.369%] (p = 0.00 < 0.05)
```