### PR TITLE
Reduce memory allocations by doing conversions in-place where possible

### DIFF
--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -67,10 +67,7 @@ impl From<LinearRgb> for Hsl {
     fn from(lrgb: LinearRgb) -> Self {
         let mut data = lrgb.data;
         for pix in &mut data {
-            let hsl = lrgb_to_hsl(*pix);
-            pix[0] = hsl[0];
-            pix[1] = hsl[1];
-            pix[2] = hsl[2];
+            *pix = lrgb_to_hsl(*pix);
         }
 
         Hsl {
@@ -85,10 +82,7 @@ impl From<Hsl> for LinearRgb {
     fn from(hsl: Hsl) -> Self {
         let mut data = hsl.data;
         for pix in &mut data {
-            let lrgb = hsl_to_lrgb(*pix);
-            pix[0] = lrgb[0];
-            pix[1] = lrgb[1];
-            pix[2] = lrgb[2];
+            *pix = hsl_to_lrgb(*pix);
         }
 
         LinearRgb {

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -65,14 +65,16 @@ impl Hsl {
 
 impl From<LinearRgb> for Hsl {
     fn from(lrgb: LinearRgb) -> Self {
-        let hsl = lrgb
-            .data
-            .iter()
-            .map(|pix| lrgb_to_hsl(*pix))
-            .collect::<Vec<_>>();
+        let mut data = lrgb.data;
+        for pix in &mut data {
+            let hsl = lrgb_to_hsl(*pix);
+            pix[0] = hsl[0];
+            pix[1] = hsl[1];
+            pix[2] = hsl[2];
+        }
 
         Hsl {
-            data: hsl,
+            data,
             width: lrgb.width,
             height: lrgb.height,
         }
@@ -81,14 +83,16 @@ impl From<LinearRgb> for Hsl {
 
 impl From<Hsl> for LinearRgb {
     fn from(hsl: Hsl) -> Self {
-        let lrgb = hsl
-            .data
-            .iter()
-            .map(|pix| hsl_to_lrgb(*pix))
-            .collect::<Vec<_>>();
+        let mut data = hsl.data;
+        for pix in &mut data {
+            let lrgb = hsl_to_lrgb(*pix);
+            pix[0] = lrgb[0];
+            pix[1] = lrgb[1];
+            pix[2] = lrgb[2];
+        }
 
         LinearRgb {
-            data: lrgb,
+            data,
             width: hsl.width,
             height: hsl.height,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use v_frame::{
     plane::Plane,
     prelude::{CastFromPrimitive, Pixel},
 };
-use yuv_rgb::{rgb_to_yuv, yuv_to_rgb, TransferFunction, transform_primaries};
+use yuv_rgb::{rgb_to_yuv, transform_primaries, yuv_to_rgb, TransferFunction};
 
 #[derive(Debug, Clone)]
 pub struct Xyb {
@@ -567,7 +567,11 @@ impl<T: Pixel> TryFrom<(LinearRgb, YuvConfig)> for Yuv<T> {
 
     fn try_from(other: (LinearRgb, YuvConfig)) -> Result<Self> {
         let config = other.1;
-        let rgb = Rgb::try_from((other.0, config.transfer_characteristics, config.color_primaries))?;
+        let rgb = Rgb::try_from((
+            other.0,
+            config.transfer_characteristics,
+            config.color_primaries,
+        ))?;
         Self::try_from((&rgb, config))
     }
 }
@@ -594,11 +598,11 @@ impl TryFrom<(LinearRgb, TransferCharacteristic, ColorPrimaries)> for Rgb {
                 transfer
             );
         }
-    
+
         if primaries == ColorPrimaries::Unspecified {
             primaries = ColorPrimaries::BT709;
             log::warn!("Color primaries not specified. Guessing {}", primaries);
-        }    
+        }
 
         let data = transform_primaries(lrgb.data, ColorPrimaries::BT709, primaries)?;
         let data = transfer.to_gamma(data)?;
@@ -616,10 +620,11 @@ impl TryFrom<(LinearRgb, TransferCharacteristic, ColorPrimaries)> for Rgb {
 impl TryFrom<(&LinearRgb, TransferCharacteristic, ColorPrimaries)> for Rgb {
     type Error = anyhow::Error;
 
-    fn try_from(other: (&LinearRgb, TransferCharacteristic, ColorPrimaries)) -> Result<Self, Self::Error> {
+    fn try_from(
+        other: (&LinearRgb, TransferCharacteristic, ColorPrimaries),
+    ) -> Result<Self, Self::Error> {
         Self::try_from((other.0.clone(), other.1, other.2))
     }
-
 }
 
 // From RGB

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,14 +412,6 @@ impl TryFrom<Rgb> for Xyb {
     }
 }
 
-impl TryFrom<&Rgb> for Xyb {
-    type Error = anyhow::Error;
-
-    fn try_from(rgb: &Rgb) -> Result<Self> {
-        Self::try_from(rgb.clone())
-    }
-}
-
 impl From<LinearRgb> for Xyb {
     fn from(lrgb: LinearRgb) -> Self {
         let data = linear_rgb_to_xyb(lrgb.data);
@@ -429,12 +421,6 @@ impl From<LinearRgb> for Xyb {
             width: lrgb.width,
             height: lrgb.height,
         }
-    }
-}
-
-impl From<&LinearRgb> for Xyb {
-    fn from(lrgb: &LinearRgb) -> Self {
-        Self::from(lrgb.clone())
     }
 }
 
@@ -468,14 +454,6 @@ impl TryFrom<Rgb> for LinearRgb {
             width: rgb.width,
             height: rgb.height,
         })
-    }
-}
-
-impl TryFrom<&Rgb> for LinearRgb {
-    type Error = anyhow::Error;
-
-    fn try_from(rgb: &Rgb) -> Result<Self> {
-        Self::try_from(rgb.clone())
     }
 }
 
@@ -516,30 +494,12 @@ impl<T: Pixel> TryFrom<(Xyb, YuvConfig)> for Yuv<T> {
     }
 }
 
-impl<T: Pixel> TryFrom<(&Xyb, YuvConfig)> for Yuv<T> {
-    type Error = anyhow::Error;
-
-    /// # Errors
-    /// - If the `YuvConfig` would produce an invalid image
-    fn try_from(other: (&Xyb, YuvConfig)) -> Result<Self> {
-        Self::try_from((other.0.clone(), other.1))
-    }
-}
-
 impl TryFrom<(Xyb, TransferCharacteristic, ColorPrimaries)> for Rgb {
     type Error = anyhow::Error;
 
     fn try_from(other: (Xyb, TransferCharacteristic, ColorPrimaries)) -> Result<Self> {
         let lrgb = LinearRgb::from(other.0);
         Self::try_from((lrgb, other.1, other.2))
-    }
-}
-
-impl TryFrom<(&Xyb, TransferCharacteristic, ColorPrimaries)> for Rgb {
-    type Error = anyhow::Error;
-
-    fn try_from(other: (&Xyb, TransferCharacteristic, ColorPrimaries)) -> Result<Self> {
-        Self::try_from((other.0.clone(), other.1, other.2))
     }
 }
 
@@ -555,12 +515,6 @@ impl From<Xyb> for LinearRgb {
     }
 }
 
-impl From<&Xyb> for LinearRgb {
-    fn from(xyb: &Xyb) -> Self {
-        Self::from(xyb.clone())
-    }
-}
-
 // From Linear RGB
 impl<T: Pixel> TryFrom<(LinearRgb, YuvConfig)> for Yuv<T> {
     type Error = anyhow::Error;
@@ -573,14 +527,6 @@ impl<T: Pixel> TryFrom<(LinearRgb, YuvConfig)> for Yuv<T> {
             config.color_primaries,
         ))?;
         Self::try_from((&rgb, config))
-    }
-}
-
-impl<T: Pixel> TryFrom<(&LinearRgb, YuvConfig)> for Yuv<T> {
-    type Error = anyhow::Error;
-
-    fn try_from(other: (&LinearRgb, YuvConfig)) -> Result<Self> {
-        Self::try_from((other.0.clone(), other.1))
     }
 }
 
@@ -614,16 +560,6 @@ impl TryFrom<(LinearRgb, TransferCharacteristic, ColorPrimaries)> for Rgb {
             transfer,
             primaries,
         })
-    }
-}
-
-impl TryFrom<(&LinearRgb, TransferCharacteristic, ColorPrimaries)> for Rgb {
-    type Error = anyhow::Error;
-
-    fn try_from(
-        other: (&LinearRgb, TransferCharacteristic, ColorPrimaries),
-    ) -> Result<Self, Self::Error> {
-        Self::try_from((other.0.clone(), other.1, other.2))
     }
 }
 

--- a/src/rgb_xyb.rs
+++ b/src/rgb_xyb.rs
@@ -54,10 +54,7 @@ pub fn linear_rgb_to_xyb(mut input: Vec<[f32; 3]>) -> Vec<[f32; 3]> {
             *mixed = cbrtf(*mixed) + (*absorb);
         }
 
-        let res = mixed_to_xyb(&mixed);
-        pix[0] = res[0];
-        pix[1] = res[1];
-        pix[2] = res[2];
+        *pix = mixed_to_xyb(&mixed);
     }
 
     input
@@ -86,20 +83,17 @@ pub fn xyb_to_linear_rgb(mut input: Vec<[f32; 3]>) -> Vec<[f32; 3]> {
             *rgb = tmp.mul_add(*rgb, *neg_bias);
         }
 
-        let mut out = gamma_rgb;
-        out[0] = INVERSE_OPSIN_ABSORBANCE_MATRIX[0] * gamma_rgb[0];
-        out[1] = INVERSE_OPSIN_ABSORBANCE_MATRIX[3] * gamma_rgb[0];
-        out[2] = INVERSE_OPSIN_ABSORBANCE_MATRIX[6] * gamma_rgb[0];
-        out[0] = INVERSE_OPSIN_ABSORBANCE_MATRIX[1].mul_add(gamma_rgb[1], out[0]);
-        out[1] = INVERSE_OPSIN_ABSORBANCE_MATRIX[4].mul_add(gamma_rgb[1], out[1]);
-        out[2] = INVERSE_OPSIN_ABSORBANCE_MATRIX[7].mul_add(gamma_rgb[1], out[2]);
-        out[0] = INVERSE_OPSIN_ABSORBANCE_MATRIX[2].mul_add(gamma_rgb[2], out[0]);
-        out[1] = INVERSE_OPSIN_ABSORBANCE_MATRIX[5].mul_add(gamma_rgb[2], out[1]);
-        out[2] = INVERSE_OPSIN_ABSORBANCE_MATRIX[8].mul_add(gamma_rgb[2], out[2]);
+        pix[0] = INVERSE_OPSIN_ABSORBANCE_MATRIX[0] * gamma_rgb[0];
+        pix[0] = INVERSE_OPSIN_ABSORBANCE_MATRIX[1].mul_add(gamma_rgb[1], pix[0]);
+        pix[0] = INVERSE_OPSIN_ABSORBANCE_MATRIX[2].mul_add(gamma_rgb[2], pix[0]);
 
-        pix[0] = out[0];
-        pix[1] = out[1];
-        pix[2] = out[2];
+        pix[1] = INVERSE_OPSIN_ABSORBANCE_MATRIX[3] * gamma_rgb[0];
+        pix[1] = INVERSE_OPSIN_ABSORBANCE_MATRIX[4].mul_add(gamma_rgb[1], pix[1]);
+        pix[1] = INVERSE_OPSIN_ABSORBANCE_MATRIX[5].mul_add(gamma_rgb[2], pix[1]);
+
+        pix[2] = INVERSE_OPSIN_ABSORBANCE_MATRIX[6] * gamma_rgb[0];
+        pix[2] = INVERSE_OPSIN_ABSORBANCE_MATRIX[7].mul_add(gamma_rgb[1], pix[2]);
+        pix[2] = INVERSE_OPSIN_ABSORBANCE_MATRIX[8].mul_add(gamma_rgb[2], pix[2]);
     }
 
     input

--- a/src/rgb_xyb.rs
+++ b/src/rgb_xyb.rs
@@ -39,7 +39,7 @@ const NEG_OPSIN_ABSORBANCE_BIAS: [f32; 3] = [-K_B0, -K_B1, -K_B2];
 /// that the input is Linear RGB. If you pass it gamma-encoded RGB, the results
 /// will be incorrect.
 #[must_use]
-pub fn linear_rgb_to_xyb(input: &[[f32; 3]]) -> Vec<[f32; 3]> {
+pub fn linear_rgb_to_xyb(mut input: Vec<[f32; 3]>) -> Vec<[f32; 3]> {
     let mut absorbance_bias = [0.0f32; 3];
     for (out, bias) in absorbance_bias.iter_mut().zip(OPSIN_ABSORBANCE_BIAS.iter()) {
         *out = -cbrtf(*bias);
@@ -66,7 +66,7 @@ pub fn linear_rgb_to_xyb(input: &[[f32; 3]]) -> Vec<[f32; 3]> {
 /// Converts 32-bit floating point XYB to Linear RGB. This does not perform
 /// gamma encoding on the resulting RGB.
 #[must_use]
-pub fn xyb_to_linear_rgb(input: &[[f32; 3]]) -> Vec<[f32; 3]> {
+pub fn xyb_to_linear_rgb(mut input: Vec<[f32; 3]>) -> Vec<[f32; 3]> {
     let mut biases_cbrt = NEG_OPSIN_ABSORBANCE_BIAS;
     for bias in &mut biases_cbrt {
         *bias = cbrtf(*bias);
@@ -190,7 +190,7 @@ mod tests {
         .unwrap();
         let expected_data = parse_xyb_txt(&expected_path);
 
-        let result = Xyb::try_from(&source).unwrap();
+        let result = Xyb::try_from(source).unwrap();
         for (exp, res) in expected_data.into_iter().zip(result.data()) {
             assert!(
                 (exp[0] - res[0]).abs() < 0.0005,
@@ -231,7 +231,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let result =
-            Rgb::try_from((&source, TransferCharacteristic::SRGB, ColorPrimaries::BT709)).unwrap();
+            Rgb::try_from((source, TransferCharacteristic::SRGB, ColorPrimaries::BT709)).unwrap();
         for (exp, res) in expected_data.into_iter().zip(result.data()) {
             assert!(
                 (exp[0] - res[0]).abs() < 0.0005,

--- a/src/yuv_rgb.rs
+++ b/src/yuv_rgb.rs
@@ -135,7 +135,6 @@ fn ypbpr_to_ycbcr<T: Pixel>(
     }
 }
 
-
 #[inline(always)]
 fn to_f32_luma<T: Pixel>(val: T, scale: f32, offset: f32) -> f32 {
     // Converts to a float value in the range 0.0..=1.0


### PR DESCRIPTION
### The idea

A lot of structs (Rgb, LinearRgb, Xyb, Hsl) store their data as a vector of pixels (`Vec<[f32; 3]>`). The conversions between all of these are currently done out-of-place (usually via `input.map(|pix| {...}).collect::<Vec<_>>()`). All of these conversions are done entirely per-pixel, so it is possible to do them in-place instead.

Basically I want to turn this

```rust
// input: Vec<[f32; 3]>

let transformed = input
  .iter()
  .map(convert)
  .collect();

Ok(transformed)
```

into this

```rust
// mut input: Vec<[f32; 3]>

for pix in &mut input {
  let new_pix = convert(pix);
  pix[0] = new_pix[0];
  pix[1] = new_pix[1];
  pix[2] = new_pix[2];
}

Ok(input)
```

Making `input` mutable (and returning it) requires owning the variable/parameter (no `&[[f32; 3]]`s), but this is already the case for most conversion functions anyways.

Note that the syntax for using the conversion functions will generally stay the same:

```rust
let data = lrgb_to_xyb(lrgb.data);
```

### Changes to `TryFrom<T>` and `From<T>`

*Note: Conversions RGB <-> YUV are not affected by this because YUV is not f32-based*
*Note: I'll just use `try_from` here. The same is true for `from`.*

Currently, `try_from(other: T)` just calls `Self::try_from(&other)`. This is fine if the conversion allocates new memory anyways, as we don't need to own any of the input data. But now that the conversion functions profit from owning an existing `data` vector, it makes sense to change this. Instead of implementing the actual logic in `TryFrom<&T>` and making `TryFrom<T>` a wrapper around that, we can turn it around:

```rust
fn try_from(other: Rgb) -> Result<Self> {
  let data = rgb.transfer.to_linear(rgb.data)?;
  let data = transform_primaries(data, ...);

  Ok(LinearRgb {
    data,
    // ...
  })
}
```

```rust
fn try_from(other: &Rgb) -> Result<Self> {
  Self::try_from(other.clone())
}
```

This leads to `TryFrom<T>` not needing to allocate any new `Vec<[f32; 3]>` during the conversion.

### Removing `TryFrom<&T>` and `From<&T>` impls that are just wrappers

*Open to discussion on this one*

Now that `TryFrom<T>` and `TryFrom<&T>` are not functionally equal anymore, I just removed `TryFrom<&T>` for these types. This makes the user need to call `.clone()` themselves, which is better IMO.

I did not touch wrappers that *are* functionally equal, like `impl TryFrom<Yuv<T>> for Rgb` and `impl TryFrom<&Yuv<T>> for Rgb`.

### Impact on performance

This increases performance, but the delta differs based on what conversion function is used exactly ("short" conversions benefit less than "long" conversions). With that in mind, the default benches are basically the best-case scenario. That said, it does look pretty nice (PR vs main):

```
yuv 8-bit 4:4:4 full to xyb
time:   [730.68 µs 731.11 µs 731.64 µs]
change: [-42.297% -42.117% -41.924%] (p = 0.00 < 0.05)

yuv 8-bit 4:2:0 full to xyb
time:   [730.68 µs 731.33 µs 732.17 µs]
change: [-44.501% -44.294% -44.129%] (p = 0.00 < 0.05)

yuv 8-bit 4:2:0 limited to xyb
time:   [720.76 µs 721.20 µs 721.61 µs]
change: [-42.156% -42.097% -42.041%] (p = 0.00 < 0.05)

yuv 10-bit 4:4:4 full to xyb
time:   [1.7639 ms 1.7699 ms 1.7765 ms]
change: [-25.385% -25.197% -25.004%] (p = 0.00 < 0.05)

yuv 10-bit 4:2:0 full to xyb
time:   [1.7952 ms 1.8039 ms 1.8127 ms]
change: [-24.093% -23.698% -23.343%] (p = 0.00 < 0.05)

yuv 10-bit 4:2:0 limited to xyb
time:   [1.8454 ms 1.8462 ms 1.8470 ms]
change: [-21.018% -20.733% -20.504%] (p = 0.00 < 0.05)
```