### PR TITLE
Revert "Use fastapprox for powf"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ nalgebra = "0.31.1"
 num-traits = "0.2.15"
 paste = "1.0.9"
 v_frame = "0.3.0"
-fastapprox = "0.3.0"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -55,3 +55,83 @@ pub fn cbrtf(x: f32) -> f32 {
     /* rounding to 24 bits is perfect in round-to-nearest mode */
     t as f32
 }
+
+// Based on https://jrfonseca.blogspot.com/2008/09/fast-sse2-pow-tables-or-polynomials.html
+pub fn powf(x: f32, y: f32) -> f32 {
+    exp2(log2(x) * y)
+}
+
+fn exp2(x: f32) -> f32 {
+    let x = x.clamp(-126.99999, 129.0);
+
+    // SAFETY: Value is clamped
+    let ipart: i32 = unsafe { (x - 0.5).to_int_unchecked() };
+    let fpart = x - ipart as f32;
+
+    let expi = f32::from_bits(((ipart + 127_i32) << 23_i32) as u32);
+    let expf = poly5(
+        fpart,
+        9.999_999_4E-1,
+        6.931_531E-1,
+        2.401_536_1E-1,
+        5.582_631_8E-2,
+        8.989_34E-3,
+        1.877_576_7E-3,
+    );
+
+    expi * expf
+}
+
+fn log2(x: f32) -> f32 {
+    let expmask = 0x7F80_0000_i32;
+    let mantmask = 0x007F_FFFF_i32;
+
+    let one_bits = 1_f32.to_bits() as i32;
+    let x_bits = x.to_bits() as i32;
+    let exp = (((x_bits & expmask) >> 23_i32) - 127_i32) as f32;
+
+    let mant = f32::from_bits(((x_bits & mantmask) | one_bits) as u32);
+
+    let polynomial = poly5(
+        mant,
+        3.115_79,
+        -3.324_199,
+        2.598_845_2,
+        -1.231_530_3,
+        3.182_133_7E-1,
+        -3.443_600_6E-2,
+    );
+    let polynomial = polynomial * (mant - 1.0);
+
+    polynomial + exp
+}
+
+#[inline(always)]
+fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
+    x.mul_add(poly4(x, c1, c2, c3, c4, c5), c0)
+}
+
+#[inline(always)]
+fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
+    x.mul_add(poly3(x, c1, c2, c3, c4), c0)
+}
+
+#[inline(always)]
+fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
+    x.mul_add(poly2(x, c1, c2, c3), c0)
+}
+
+#[inline(always)]
+fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
+    x.mul_add(poly1(x, c1, c2), c0)
+}
+
+#[inline(always)]
+fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
+    x.mul_add(poly0(x, c1), c0)
+}
+
+#[inline(always)]
+const fn poly0(_x: f32, c0: f32) -> f32 {
+    c0
+}

--- a/src/yuv_rgb/transfer.rs
+++ b/src/yuv_rgb/transfer.rs
@@ -3,8 +3,7 @@ use av_data::pixel::TransferCharacteristic;
 use debug_unreachable::debug_unreachable;
 use std::slice::from_raw_parts_mut;
 
-use fastapprox::fast::pow as powf;
-
+use crate::fastmath::powf;
 
 pub trait TransferFunction {
     fn to_linear(&self, input: Vec<[f32; 3]>) -> Result<Vec<[f32; 3]>>;
@@ -342,7 +341,7 @@ fn arib_b67_inverse_oetf(x: f32) -> f32 {
     if x <= 0.5 {
         (x * x) * (1.0 / 3.0)
     } else {
-        (fastapprox::fast::exp((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) / 12.0
+        (((x - ARIB_B67_C) / ARIB_B67_A).exp() + ARIB_B67_B) / 12.0
     }
 }
 
@@ -354,9 +353,6 @@ fn arib_b67_oetf(x: f32) -> f32 {
         (3.0 * x).sqrt()
     } else {
         // ARIB_B67_A * (12.0 * x - ARIB_B67_B).ln() + ARIB_B67_C
-        ARIB_B67_A.mul_add(
-            fastapprox::fast::ln(12.0f32.mul_add(x, -ARIB_B67_B)),
-            ARIB_B67_C,
-        )
+        ARIB_B67_A.mul_add((12.0f32.mul_add(x, -ARIB_B67_B)).ln(), ARIB_B67_C)
     }
 }


### PR DESCRIPTION
Reverts rust-av/yuvxyb#8

This is giving inconsistent results, on some machines giving as much as a 50% slowdown.