### PR TITLE
Add "slowmath" mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ homepage = "https://github.com/rust-av/yuvxyb"
 repository = "https://github.com/rust-av/yuvxyb"
 exclude = ["test_data", "yuvxyb-dump"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["fastmath"]
+fastmath = []
 
 [dependencies]
 anyhow = "1.0.65"

--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -66,13 +66,22 @@ pub fn cbrtf(x: f32) -> f32 {
     t as f32
 }
 
-// Based on https://jrfonseca.blogspot.com/2008/09/fast-sse2-pow-tables-or-polynomials.html
 #[cfg(not(feature = "fastmath"))]
 #[inline(always)]
 pub fn powf(x: f32, y: f32) -> f32 {
     x.powf(y)
 }
 
+// The following implementation of powf is based on José Fonseca's 
+// polynomial-based implementation, ported to Rust as scalar code
+// so that the compiler can auto-vectorize and otherwise optimize.
+// Original: https://jrfonseca.blogspot.com/2008/09/fast-sse2-pow-tables-or-polynomials.html
+
+/// Computes x raised to the power of y.
+/// 
+/// This optimized approach heavily benefits from FMA instructions being
+/// available on the target platform. Make sure to enable the relevant
+/// CPU feature during compilation.
 #[cfg(feature = "fastmath")]
 pub fn powf(x: f32, y: f32) -> f32 {
     exp2(log2(x) * y)

--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -3,19 +3,6 @@
  * Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
  * Debugged and optimized by Bruce D. Evans.
  */
-/*
- * ====================================================
- * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
- *
- * Developed at SunPro, a Sun Microsystems, Inc. business.
- * Permission to use, copy, modify, and distribute this
- * software is freely granted, provided that this notice
- * is preserved.
- * ====================================================
- */
-/* cbrtf(x)
- * Return cube root of x
- */
 
 use core::f32;
 
@@ -27,6 +14,20 @@ use core::f32;
 pub fn cbrtf(x: f32) -> f32 {
     x.cbrt()
 }
+
+// The following copyright notice applies to the optimized cube root
+// function (cbrtf) directly below it:
+
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunPro, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
 
 /// Cube root (f32)
 ///

--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -19,14 +19,24 @@
 
 use core::f32;
 
-const B1: u32 = 709_958_130; /* B1 = (127-127.0/3-0.03306235651)*2**23 */
 
 /// Cube root (f32)
 ///
 /// Computes the cube root of the argument.
+#[cfg(not(feature = "fastmath"))]
+pub fn cbrtf(x: f32) -> f32 {
+    x.cbrt()
+}
+
+/// Cube root (f32)
+///
+/// Computes the cube root of x.
 /// The argument must be normal (not NaN, +/-INF or subnormal).
 /// This is required for optimization purposes.
+#[cfg(feature = "fastmath")]
 pub fn cbrtf(x: f32) -> f32 {
+    const B1: u32 = 709_958_130; /* B1 = (127-127.0/3-0.03306235651)*2**23 */
+
     let mut r: f64;
     let mut t: f64;
     let mut ui: u32 = x.to_bits();
@@ -57,10 +67,18 @@ pub fn cbrtf(x: f32) -> f32 {
 }
 
 // Based on https://jrfonseca.blogspot.com/2008/09/fast-sse2-pow-tables-or-polynomials.html
+#[cfg(not(feature = "fastmath"))]
+#[inline(always)]
+pub fn powf(x: f32, y: f32) -> f32 {
+    x.powf(y)
+}
+
+#[cfg(feature = "fastmath")]
 pub fn powf(x: f32, y: f32) -> f32 {
     exp2(log2(x) * y)
 }
 
+#[cfg(feature = "fastmath")]
 fn exp2(x: f32) -> f32 {
     let x = x.clamp(-126.99999, 129.0);
 
@@ -82,6 +100,7 @@ fn exp2(x: f32) -> f32 {
     expi * expf
 }
 
+#[cfg(feature = "fastmath")]
 fn log2(x: f32) -> f32 {
     let expmask = 0x7F80_0000_i32;
     let mantmask = 0x007F_FFFF_i32;
@@ -106,31 +125,37 @@ fn log2(x: f32) -> f32 {
     polynomial + exp
 }
 
+#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
     x.mul_add(poly4(x, c1, c2, c3, c4, c5), c0)
 }
 
+#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
     x.mul_add(poly3(x, c1, c2, c3, c4), c0)
 }
 
+#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
     x.mul_add(poly2(x, c1, c2, c3), c0)
 }
 
+#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
     x.mul_add(poly1(x, c1, c2), c0)
 }
 
+#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
     x.mul_add(poly0(x, c1), c0)
 }
 
+#[cfg(feature = "fastmath")]
 #[inline(always)]
 const fn poly0(_x: f32, c0: f32) -> f32 {
     c0


### PR DESCRIPTION
To be accurate, I added a "fastmath" feature which is enabled by default. Enabling the feature just enables the already existing code in `fastmath.rs`. Disabling it uses the built-in `powf`/`cbrt` functions provided by Rust (which are translated to LLVM intrinsics).

Just to have a rough idea of the speed decrease (fastmath enabled vs disabled):
```
yuv 8-bit 4:4:4 full to xyb
time:   [3.5487 ms 3.5647 ms 3.5822 ms]
change: [+513.45% +517.33% +521.43%] (p = 0.00 < 0.05)

yuv 8-bit 4:2:0 full to xyb
time:   [3.4657 ms 3.4746 ms 3.4849 ms]
change: [+493.40% +495.14% +497.23%] (p = 0.00 < 0.05)

yuv 8-bit 4:2:0 limited to xyb
time:   [3.7191 ms 3.7209 ms 3.7226 ms]
change: [+545.95% +546.45% +546.95%] (p = 0.00 < 0.05)

yuv 10-bit 4:4:4 full to xyb
time:   [7.1267 ms 7.1295 ms 7.1324 ms]
change: [+337.71% +339.27% +340.95%] (p = 0.00 < 0.05)

yuv 10-bit 4:2:0 full to xyb
time:   [7.0227 ms 7.0311 ms 7.0394 ms]
change: [+328.11% +329.43% +330.87%] (p = 0.00 < 0.05)

yuv 10-bit 4:2:0 limited to xyb
time:   [7.0826 ms 7.1016 ms 7.1213 ms]
change: [+330.38% +331.61% +332.93%] (p = 0.00 < 0.05)
```