### PR TITLE
Introduce optimized `expf` function for the HLG transfer function

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -194,6 +194,23 @@ fn bench_yuv_10b_420_limited_to_xyb(c: &mut Criterion) {
     });
 }
 
+fn bench_hybrid_log_gamma(c: &mut Criterion) {
+    c.bench_function("rgb to lrgb via hybrid log-gamma system", |b| {
+        let input = {
+            let yuv = make_yuv_10b(
+                (1, 1),
+                false,
+                MatrixCoefficients::BT2020NonConstantLuminance,
+                TransferCharacteristic::HybridLogGamma,
+                ColorPrimaries::BT2020,
+            );
+            Rgb::try_from(&yuv).unwrap()
+        };
+
+        b.iter(|| LinearRgb::try_from(black_box(input.clone())).unwrap())
+    });
+}
+
 criterion_group!(
     benches,
     bench_yuv_8b_444_full_to_xyb,
@@ -201,6 +218,7 @@ criterion_group!(
     bench_yuv_8b_420_limited_to_xyb,
     bench_yuv_10b_444_full_to_xyb,
     bench_yuv_10b_420_full_to_xyb,
-    bench_yuv_10b_420_limited_to_xyb
+    bench_yuv_10b_420_limited_to_xyb,
+    bench_hybrid_log_gamma,
 );
 criterion_main!(benches);

--- a/src/fastmath.rs
+++ b/src/fastmath.rs
@@ -158,6 +158,18 @@ const fn poly0(_x: f32, c0: f32) -> f32 {
     c0
 }
 
+// Based on a C implementation from stackoverflow:
+// https://stackoverflow.com/a/10792321/9727602
+
+/// Computes e raised to the power of x.
+#[cfg(feature = "fastmath")]
+pub fn expf(x: f32) -> f32 {
+    let t = 1.442_695_041 * x; // log2(e) * x
+    let ft = t.floor();
+    let f = t - ft;
+    exp2(ft) * exp2(f)
+}
+
 /// Computes the cube root of x.
 #[cfg(not(feature = "fastmath"))]
 #[inline(always)]
@@ -170,4 +182,11 @@ pub fn cbrtf(x: f32) -> f32 {
 #[inline(always)]
 pub fn powf(x: f32, y: f32) -> f32 {
     x.powf(y)
+}
+
+/// Computes e raised to the power of x.
+#[cfg(not(feature = "fastmath"))]
+#[inline(always)]
+pub fn expf(x: f32) -> f32 {
+    x.exp()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 #![warn(clippy::use_debug)]
 #![warn(clippy::verbose_file_reads)]
 
-mod fastmath;
+mod math;
 mod rgb_xyb;
 mod yuv_rgb;
 

--- a/src/math.rs
+++ b/src/math.rs
@@ -3,6 +3,19 @@
 #![allow(clippy::cast_sign_loss)]
 
 use core::f32;
+use core::f32::consts::LOG2_E;
+
+/// Computes the cube root of x.
+/// 
+/// The argument must be normal (not NaN, +/-INF or subnormal).
+/// This is required for optimization purposes.
+pub fn cbrtf(x: f32) -> f32 {
+    if cfg!(feature = "fastmath") {
+        cbrtf_fast(x)
+    } else {
+        x.cbrt()
+    }
+}
 
 // The following cbrtf implementation is a port of FreeBSDs cbrtf function
 // found in <root>/lib/msun/src/s_cbrtf.c, modified to remove some edge case
@@ -25,13 +38,7 @@ use core::f32;
  * is preserved.
  * ====================================================
  */
-
-/// Computes the cube root of x.
-///
-/// The argument must be normal (not NaN, +/-INF or subnormal).
-/// This is required for optimization purposes.
-#[cfg(feature = "fastmath")]
-pub fn cbrtf(x: f32) -> f32 {
+fn cbrtf_fast(x: f32) -> f32 {
     // B1 = (127-127.0/3-0.03306235651)*2**23
     const B1: u32 = 709_958_130;
 
@@ -60,6 +67,7 @@ pub fn cbrtf(x: f32) -> f32 {
     t as f32
 }
 
+
 // The following implementation of powf is based on José Fonseca's
 // polynomial-based implementation, ported to Rust as scalar code
 // so that the compiler can auto-vectorize and otherwise optimize.
@@ -70,12 +78,14 @@ pub fn cbrtf(x: f32) -> f32 {
 /// This implementation benefits a lot from FMA instructions being
 /// available on the target platform. Make sure to enable the relevant
 /// CPU feature during compilation.
-#[cfg(feature = "fastmath")]
 pub fn powf(x: f32, y: f32) -> f32 {
-    exp2(log2(x) * y)
+    if cfg!(feature = "fastmath") {
+        exp2(log2(x) * y)
+    } else {
+        x.powf(y)
+    }
 }
 
-#[cfg(feature = "fastmath")]
 fn exp2(x: f32) -> f32 {
     let x = x.clamp(-126.99999, 129.0);
 
@@ -97,7 +107,6 @@ fn exp2(x: f32) -> f32 {
     expi * expf
 }
 
-#[cfg(feature = "fastmath")]
 fn log2(x: f32) -> f32 {
     let expmask = 0x7F80_0000_i32;
     let mantmask = 0x007F_FFFF_i32;
@@ -122,37 +131,31 @@ fn log2(x: f32) -> f32 {
     polynomial + exp
 }
 
-#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
     x.mul_add(poly4(x, c1, c2, c3, c4, c5), c0)
 }
 
-#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
     x.mul_add(poly3(x, c1, c2, c3, c4), c0)
 }
 
-#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
     x.mul_add(poly2(x, c1, c2, c3), c0)
 }
 
-#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
     x.mul_add(poly1(x, c1, c2), c0)
 }
 
-#[cfg(feature = "fastmath")]
 #[inline(always)]
 fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
     x.mul_add(poly0(x, c1), c0)
 }
 
-#[cfg(feature = "fastmath")]
 #[inline(always)]
 const fn poly0(_x: f32, c0: f32) -> f32 {
     c0
@@ -162,31 +165,13 @@ const fn poly0(_x: f32, c0: f32) -> f32 {
 // https://stackoverflow.com/a/10792321/9727602
 
 /// Computes e raised to the power of x.
-#[cfg(feature = "fastmath")]
 pub fn expf(x: f32) -> f32 {
-    let t = 1.442_695_041 * x; // log2(e) * x
-    let ft = t.floor();
-    let f = t - ft;
-    exp2(ft) * exp2(f)
-}
-
-/// Computes the cube root of x.
-#[cfg(not(feature = "fastmath"))]
-#[inline(always)]
-pub fn cbrtf(x: f32) -> f32 {
-    x.cbrt()
-}
-
-/// Computes x raised to the power of y.
-#[cfg(not(feature = "fastmath"))]
-#[inline(always)]
-pub fn powf(x: f32, y: f32) -> f32 {
-    x.powf(y)
-}
-
-/// Computes e raised to the power of x.
-#[cfg(not(feature = "fastmath"))]
-#[inline(always)]
-pub fn expf(x: f32) -> f32 {
-    x.exp()
+    if cfg!(feature = "fastmath") {
+        let t = LOG2_E * x;
+        let ft = t.floor();
+        let f = t - ft;
+        exp2(ft) * exp2(f)
+    } else {
+        x.exp()
+    }
 }

--- a/src/rgb_xyb.rs
+++ b/src/rgb_xyb.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::many_single_char_names)]
 
-use crate::fastmath::cbrtf;
+use crate::math::cbrtf;
 
 const K_M02: f32 = 0.078f32;
 const K_M00: f32 = 0.30f32;

--- a/src/yuv_rgb/transfer.rs
+++ b/src/yuv_rgb/transfer.rs
@@ -3,7 +3,7 @@ use av_data::pixel::TransferCharacteristic;
 use debug_unreachable::debug_unreachable;
 use std::slice::from_raw_parts_mut;
 
-use crate::fastmath::powf;
+use crate::fastmath::{powf, expf};
 
 pub trait TransferFunction {
     fn to_linear(&self, input: Vec<[f32; 3]>) -> Result<Vec<[f32; 3]>>;
@@ -331,7 +331,7 @@ fn arib_b67_inverse_oetf(x: f32) -> f32 {
     if x <= 0.5 {
         (x * x) * (1.0 / 3.0)
     } else {
-        (((x - ARIB_B67_C) / ARIB_B67_A).exp() + ARIB_B67_B) / 12.0
+        expf(((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) / 12.0
     }
 }
 

--- a/src/yuv_rgb/transfer.rs
+++ b/src/yuv_rgb/transfer.rs
@@ -3,7 +3,7 @@ use av_data::pixel::TransferCharacteristic;
 use debug_unreachable::debug_unreachable;
 use std::slice::from_raw_parts_mut;
 
-use crate::fastmath::{powf, expf};
+use crate::math::{powf, expf};
 
 pub trait TransferFunction {
     fn to_linear(&self, input: Vec<[f32; 3]>) -> Result<Vec<[f32; 3]>>;

--- a/src/yuv_rgb/transfer.rs
+++ b/src/yuv_rgb/transfer.rs
@@ -331,7 +331,7 @@ fn arib_b67_inverse_oetf(x: f32) -> f32 {
     if x <= 0.5 {
         (x * x) * (1.0 / 3.0)
     } else {
-        expf(((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) / 12.0
+        (expf((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) / 12.0
     }
 }
 


### PR DESCRIPTION
1. Introduce `fastmath::expf(f32) -> f32`. This is only used by the Hybrid log-gamma system, but makes a significant difference on my machine where `f32::exp(self) -> f32` links to glibc to call `expf`.
2. Refactor the `fastmath` module slightly, so it uses `if cfg!(...) {` instead of `#[cfg(...)]`. This avoids duplicate function signatures and makes the code neater overall, at least IMHO.
3. Rename the `fastmath` module to just `math` because it also contains the "fallback" math, and is used even if the `fastmath` feature is disabled.

To check if the loss in precision from this change is acceptable, I wrote the following test:

```rust
#[test]
fn test_expf() {
    const MAX_DELTA: f32 = 1e-6;

    if cfg!(not(feature = "fastmath")) {
        panic!("fastmath feature should be enabled for this test!");
    }

    let mut f = 0f32;
    while f <= 1.0 {
        let fast = math::expf(f);
        let slow = f.exp();
        let delta = (fast - slow).abs();

        assert!(delta < MAX_DELTA, "{delta} is larger than allowed delta of {MAX_DELTA}");
        f += f32::EPSILON;
    }
}
```

Since we assume our floats are always in the range [0, 1], this should be a decent test. It looks like any MAX_DELTA down to `8e-7` will pass. (Note: I know this is not exhaustive since f32::EPSILON is not the correct epsilon for values below 0, but I thought it was "good enough" and it is also a simple way to avoid testing subnormals).
