### PR TITLE
Remove anyhow, implement concrete error types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,12 @@ default = ["fastmath"]
 fastmath = []
 
 [dependencies]
-anyhow = "1.0.65"
 av-data = "0.4.1"
-debug_unreachable = { package = "new_debug_unreachable", version = "1.0.4" }
 log = "0.4.17"
 nalgebra = "0.32.2"
 num-traits = "0.2.15"
 paste = "1.0.9"
+thiserror = "1.0.40"
 v_frame = "0.3.0"
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,49 @@
+use thiserror::Error;
+
+/// Error type for when converting data from one color space to another fails.
+///
+/// Note that some conversions are infallible. These conversions will be
+/// implemented in the [`From<T>`] trait. Check the type's documentation
+/// to see which conversions are implemented.
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum ConversionError {
+    #[error("Cannot convert between YUV and RGB using these matrix coefficients.")]
+    UnsupportedMatrixCoefficients,
+    #[error("No matrix coefficients were specified.")]
+    UnspecifiedMatrixCoefficients,
+    #[error("Cannot convert between YUV and RGB using these primaries.")]
+    UnsupportedColorPrimaries,
+    #[error("No primaries were specified.")]
+    UnspecifiedColorPrimaries,
+    #[error("Cannot convert between YUV and RGB using this transfer function.")]
+    UnsupportedTransferCharacteristic,
+    #[error("No transfer function was specified.")]
+    UnspecifiedTransferCharacteristic,
+}
+
+/// Error type for when creating one of the colorspace structs fails.
+///
+/// Note that the [`Yuv`] struct uses a separate Error type, [`YuvError`].
+///
+/// # Example
+/// ```
+/// use yuvxyb::{CreationError, LinearRgb};
+///
+/// // 10 pixels is not enough for the resolution 1920x1080
+/// let float_data = vec![[0f32; 3]; 10];
+/// let result = LinearRgb::new(float_data, 1920, 1080);
+///
+/// assert!(result.is_err());
+/// assert_eq!(result.unwrap_err(), CreationError::ResolutionMismatch);
+/// ```
+///
+/// [`Yuv`]: crate::yuv::Yuv
+/// [`YuvError`]: crate::yuv::YuvError
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum CreationError {
+    /// There is a mismatch between the supplied data and the supplied resolution.
+    ///
+    /// Generally, data.len() should be equal to width * height.
+    #[error("Data length does not match the specified dimensions.")]
+    ResolutionMismatch,
+}

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -1,6 +1,4 @@
-use anyhow::{bail, Result};
-
-use crate::LinearRgb;
+use crate::{CreationError, LinearRgb};
 
 /// HSL Color Space: Hue, Saturation, Lightness.
 ///
@@ -26,9 +24,9 @@ pub struct Hsl {
 impl Hsl {
     /// # Errors
     /// - If data length does not match `width * height`
-    pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self> {
+    pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self, CreationError> {
         if data.len() != width * height {
-            bail!("Data length does not match specified dimensions");
+            return Err(CreationError::ResolutionMismatch);
         }
 
         Ok(Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,17 +35,19 @@ mod math;
 mod rgb_xyb;
 mod yuv_rgb;
 
+mod errors;
 mod hsl;
 mod linear_rgb;
 mod rgb;
 mod xyb;
 mod yuv;
 
+pub use crate::errors::{ConversionError, CreationError};
 pub use crate::hsl::Hsl;
 pub use crate::linear_rgb::LinearRgb;
 pub use crate::rgb::Rgb;
 pub use crate::xyb::Xyb;
-pub use crate::yuv::{Yuv, YuvConfig};
+pub use crate::yuv::{Yuv, YuvConfig, YuvError};
 pub use av_data::pixel::{ColorPrimaries, MatrixCoefficients, TransferCharacteristic};
 pub use num_traits::{FromPrimitive, ToPrimitive};
 pub use v_frame::{

--- a/src/math.rs
+++ b/src/math.rs
@@ -6,7 +6,7 @@ use core::f32;
 use core::f32::consts::LOG2_E;
 
 /// Computes the cube root of x.
-/// 
+///
 /// The argument must be normal (not NaN, +/-INF or subnormal).
 /// This is required for optimization purposes.
 pub fn cbrtf(x: f32) -> f32 {
@@ -66,7 +66,6 @@ fn cbrtf_fast(x: f32) -> f32 {
     // rounding to 24 bits is perfect in round-to-nearest mode
     t as f32
 }
-
 
 // The following implementation of powf is based on José Fonseca's
 // polynomial-based implementation, ported to Rust as scalar code

--- a/src/xyb.rs
+++ b/src/xyb.rs
@@ -1,7 +1,6 @@
-use anyhow::{bail, Result};
 use v_frame::prelude::Pixel;
 
-use crate::{rgb_xyb::linear_rgb_to_xyb, LinearRgb, Rgb, Yuv};
+use crate::{rgb_xyb::linear_rgb_to_xyb, ConversionError, CreationError, LinearRgb, Rgb, Yuv};
 
 #[derive(Debug, Clone)]
 pub struct Xyb {
@@ -13,9 +12,9 @@ pub struct Xyb {
 impl Xyb {
     /// # Errors
     /// - If data length does not match `width * height`
-    pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self> {
+    pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self, CreationError> {
         if data.len() != width * height {
-            bail!("Data length does not match specified dimensions");
+            return Err(CreationError::ResolutionMismatch);
         }
 
         Ok(Self {
@@ -58,26 +57,26 @@ impl Xyb {
 }
 
 impl<T: Pixel> TryFrom<Yuv<T>> for Xyb {
-    type Error = anyhow::Error;
+    type Error = ConversionError;
 
-    fn try_from(yuv: Yuv<T>) -> Result<Self> {
+    fn try_from(yuv: Yuv<T>) -> Result<Self, Self::Error> {
         Self::try_from(&yuv)
     }
 }
 
 impl<T: Pixel> TryFrom<&Yuv<T>> for Xyb {
-    type Error = anyhow::Error;
+    type Error = ConversionError;
 
-    fn try_from(yuv: &Yuv<T>) -> Result<Self> {
+    fn try_from(yuv: &Yuv<T>) -> Result<Self, Self::Error> {
         let rgb = Rgb::try_from(yuv)?;
         Self::try_from(rgb)
     }
 }
 
 impl TryFrom<Rgb> for Xyb {
-    type Error = anyhow::Error;
+    type Error = ConversionError;
 
-    fn try_from(rgb: Rgb) -> Result<Self> {
+    fn try_from(rgb: Rgb) -> Result<Self, Self::Error> {
         let lrgb = LinearRgb::try_from(rgb)?;
         Ok(Self::from(lrgb))
     }

--- a/src/yuv_rgb.rs
+++ b/src/yuv_rgb.rs
@@ -231,15 +231,14 @@ fn pixel_offset(bit_depth: u8, full_range: bool, chroma: bool) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Yuv;
-    use anyhow::Result;
+    use crate::{ConversionError, Yuv};
     use av_data::pixel::{ColorPrimaries, MatrixCoefficients, TransferCharacteristic};
     use num_traits::clamp;
     use v_frame::{frame::Frame, plane::Plane};
 
     /// Converts 8..=16-bit YUV data to 32-bit floating point Linear RGB
     /// in a range of 0.0..=1.0;
-    fn yuv_to_linear_rgb<T: Pixel>(input: &Yuv<T>) -> Result<Vec<[f32; 3]>> {
+    fn yuv_to_linear_rgb<T: Pixel>(input: &Yuv<T>) -> Result<Vec<[f32; 3]>, ConversionError> {
         let rgb = yuv_to_rgb(input)?;
         let config = input.config();
         let data = config.transfer_characteristics.to_linear(rgb)?;
@@ -256,7 +255,7 @@ mod tests {
         width: usize,
         height: usize,
         config: YuvConfig,
-    ) -> Result<Yuv<T>> {
+    ) -> Result<Yuv<T>, ConversionError> {
         let data = transform_primaries(input, ColorPrimaries::BT709, config.color_primaries)?;
         let data = config.transfer_characteristics.to_gamma(data)?;
         rgb_to_yuv(&data, width, height, config)

--- a/src/yuv_rgb/color.rs
+++ b/src/yuv_rgb/color.rs
@@ -92,7 +92,7 @@ pub fn get_yuv_constants_from_primaries(
     Ok((kr, kb))
 }
 
-pub fn get_yuv_constants(matrix: MatrixCoefficients) -> Result<(f32, f32), ConversionError> {
+pub const fn get_yuv_constants(matrix: MatrixCoefficients) -> Result<(f32, f32), ConversionError> {
     Ok(match matrix {
         MatrixCoefficients::Identity => (0.0, 0.0),
         MatrixCoefficients::BT470M => (0.3, 0.11),
@@ -135,7 +135,7 @@ pub fn ncl_rgb_to_yuv_matrix_from_kr_kb(kr: f32, kb: f32) -> Matrix3<f32> {
     Matrix3::from_row_slice(&ret)
 }
 
-pub fn get_primaries_xy(primaries: ColorPrimaries) -> Result<[[f32; 2]; 3], ConversionError> {
+pub const fn get_primaries_xy(primaries: ColorPrimaries) -> Result<[[f32; 2]; 3], ConversionError> {
     Ok(match primaries {
         ColorPrimaries::BT470M => [[0.670, 0.330], [0.210, 0.710], [0.140, 0.080]],
         ColorPrimaries::BT470BG => [[0.640, 0.330], [0.290, 0.600], [0.150, 0.060]],


### PR DESCRIPTION
FYI: The `thiserror` crate does not appear in the public API. This is still a breaking change though.

I also removed `debug_unreachable` because I don't think the very small performance increase is worth the risk of UB down the line (I understand that the current code will not cause UB, but it feels like a code smell).

Anyways, the error types `CreationError` and `ConversionError` are exported under the `yuvxyb::errors` namespace. `YuvError` kind of belongs to the `Yuv` struct and is in the same (root) namespace.

I don't implement things like this often (incl. docs), so let me know what you think. 