### PR TITLE
Clippy updates

### DIFF
--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -50,7 +50,6 @@ impl Hsl {
 
     #[must_use]
     #[inline(always)]
-    #[allow(clippy::missing_const_for_fn)]
     pub fn into_data(self) -> Vec<[f32; 3]> {
         self.data
     }

--- a/src/linear_rgb.rs
+++ b/src/linear_rgb.rs
@@ -43,7 +43,6 @@ impl LinearRgb {
 
     #[must_use]
     #[inline(always)]
-    #[allow(clippy::missing_const_for_fn)]
     pub fn into_data(self) -> Vec<[f32; 3]> {
         self.data
     }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -65,7 +65,6 @@ impl Rgb {
 
     #[must_use]
     #[inline(always)]
-    #[allow(clippy::missing_const_for_fn)]
     pub fn into_data(self) -> Vec<[f32; 3]> {
         self.data
     }

--- a/src/rgb_xyb.rs
+++ b/src/rgb_xyb.rs
@@ -150,7 +150,7 @@ mod tests {
         let input = fs::read_to_string(path).unwrap();
         input
             .lines()
-            .map(|l| l.trim())
+            .map(str::trim)
             .filter(|l| !l.is_empty())
             .map(|l| {
                 let (x, l) = l.split_once(' ').unwrap();
@@ -168,7 +168,7 @@ mod tests {
         let expected_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("test_data")
             .join("tank_xyb.txt");
-        let source = image::open(&source_path).unwrap();
+        let source = image::open(source_path).unwrap();
         let source_data = source
             .to_rgb32f()
             .chunks_exact(3)
@@ -217,7 +217,11 @@ mod tests {
             .join("tank_srgb.png");
         let source_data = parse_xyb_txt(&source_path);
         let source = Xyb::new(source_data, 1448, 1080).unwrap();
-        let expected = image::open(&expected_path).unwrap();
+        let expected = image::open(expected_path).unwrap();
+
+        // Fixing this would result in worse code, and this
+        // needless collect() doesn't really matter in tests
+        #[allow(clippy::needless_collect)]
         let expected_data = expected
             .to_rgb32f()
             .chunks_exact(3)

--- a/src/xyb.rs
+++ b/src/xyb.rs
@@ -38,7 +38,6 @@ impl Xyb {
 
     #[must_use]
     #[inline(always)]
-    #[allow(clippy::missing_const_for_fn)]
     pub fn into_data(self) -> Vec<[f32; 3]> {
         self.data
     }

--- a/src/yuv.rs
+++ b/src/yuv.rs
@@ -68,6 +68,10 @@ impl<T: Pixel> Yuv<T> {
     ///   frame data
     /// - If `data` contains values which are not valid for the specified bit
     ///   depth (note: out-of-range values for limited range are allowed)
+    // Clippy complains about T::to_u16 maybe panicking, but it can be assumed
+    // to never panic because the Pixel trait is only implemented by u8 and
+    // u16, both of which will successfully return a u16 from to_u16.
+    #[allow(clippy::missing_panics_doc)]
     pub fn new(data: Frame<T>, config: YuvConfig) -> Result<Self, YuvError> {
         if config.subsampling_x != data.planes[1].cfg.xdec as u8
             || config.subsampling_x != data.planes[2].cfg.xdec as u8


### PR DESCRIPTION
The `#[allow(clippy::missing_panics_doc)]` isn't a perfect solution, but good enough IMHO. Rewriting the code would be more effort due to testing (the `to_u16().expect()` is optimized away and cannot panic in monomorphized code).

Could be something to do later - the traits required by Pixel provide some functionality that can make it statically panic-free for any T: Pixel, but that doesn't seem very important