### PR TITLE
Remove dependency on syn v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ default = ["fastmath"]
 fastmath = []
 
 [dependencies]
-av-data = "0.4.1"
+av-data = "0.4.2"
 log = "0.4.17"
 num-traits = "0.2.15"
 paste = "1.0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,16 @@ fastmath = []
 [dependencies]
 av-data = "0.4.1"
 log = "0.4.17"
-nalgebra = "0.32.2"
 num-traits = "0.2.15"
 paste = "1.0.9"
 thiserror = "1.0.40"
 v_frame = "0.3.0"
+
+[dependencies.nalgebra]
+version = "0.32.2"
+# The default features include macros that we don't need
+default-features = false
+features = ["std"]
 
 [dev-dependencies]
 criterion = "0.4.0"


### PR DESCRIPTION
We don't use `nalgebra-macros` and it adds a dependency on syn v1.
av-data 0.4.2 is a release specifically for removing the dependency on syn v1. That should be everything