### PR TITLE
Implement abstraction over mul_add

### DIFF
--- a/src/math.rs
+++ b/src/math.rs
@@ -177,6 +177,7 @@ pub fn expf(x: f32) -> f32 {
 
 /// Computes (a * b) + c, leveraging FMA if available
 #[inline]
+#[allow(clippy::suboptimal_flops)]
 pub fn multiply_add(a: f32, b: f32, c: f32) -> f32 {
     if cfg!(target_feature = "fma") {
         a.mul_add(b, c)

--- a/src/math.rs
+++ b/src/math.rs
@@ -132,27 +132,27 @@ fn log2(x: f32) -> f32 {
 
 #[inline(always)]
 fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
-    x.mul_add(poly4(x, c1, c2, c3, c4, c5), c0)
+    multiply_add(x, poly4(x, c1, c2, c3, c4, c5), c0)
 }
 
 #[inline(always)]
 fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
-    x.mul_add(poly3(x, c1, c2, c3, c4), c0)
+    multiply_add(x, poly3(x, c1, c2, c3, c4), c0)
 }
 
 #[inline(always)]
 fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
-    x.mul_add(poly2(x, c1, c2, c3), c0)
+    multiply_add(x, poly2(x, c1, c2, c3), c0)
 }
 
 #[inline(always)]
 fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
-    x.mul_add(poly1(x, c1, c2), c0)
+    multiply_add(x, poly1(x, c1, c2), c0)
 }
 
 #[inline(always)]
 fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
-    x.mul_add(poly0(x, c1), c0)
+    multiply_add(x, poly0(x, c1), c0)
 }
 
 #[inline(always)]
@@ -172,5 +172,15 @@ pub fn expf(x: f32) -> f32 {
         exp2(ft) * exp2(f)
     } else {
         x.exp()
+    }
+}
+
+/// Computes (a * b) + c, leveraging FMA if available
+#[inline]
+pub fn multiply_add(a: f32, b: f32, c: f32) -> f32 {
+    if cfg!(target_feature = "fma") {
+        a.mul_add(b, c)
+    } else {
+        a * b + c
     }
 }


### PR DESCRIPTION
The codegen for `mul_add` is a bit nonsensical when FMA is disabled: [Compiler Explorer](https://rust.godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DEArgoKkl9ZATwDKjdAGFUtEywZ7HAGTwNMAHLuAEaYxCDSAA6oCoR2DC5uHnrRsbYCvv5BLKHh0laYNvFCBEzEBInunlyWmNbpDCVlBJmBIWERlqXllck15s2t2bkRAJSWqCbEyOwckSbBANRUDIssJrQA%2Bkzo6BBMIMsAzABMpIvBh1Sn58hXp6OLALQApEfYxyeLLwDsAEIvDQAQUWoMWTAAdOstjs9sFbqNAUDfgARJEcca0TgAVl4ng4WlIqE4ACUzARFgpJtNMN8TkceKQCJoMeMANYgI5HCFc3l8/kANn0nEkeJZRM4vAUIA0TJZ4zgsCQaBYkToYXIlBVavo4WIXB%2BAtlNFoBDC0oglwJvGCfjKAE9OIzbcxiPaAPLBbSFZncXgqtiCd0MWiO62kLDBEzAJxiWjSv0RzAsQzAcTh/DEH14ABumAThMwqkKJjNTt4fjNWPDtDwwWIDpcWHFBGIeBY5fGVAMwAUADU8JgAO7uyKMcsyQQiMTsKST%2BRKNTi3Q1AxGECmcz6OvSyDjVCRBoJp5ORYHghPeh52hvFFfE%2BLbrATAX5DzW%2BqAAcAqeAskTxzE5eFQPNiDbLBdygZg2BATB8AaUgczEExZhODQTh4UZxgKIp7AgRxemqUgfD8Nocg6GpUjiARCJSGJqIYIZ2nCfo6mzAQmh6Vwqj0HCGk4lpSOGCiumaWj%2Bm6QSsmYiRsOpGZZOFDhcVIfFCWJDhFk3AhkEWLgIUNCENEWCBcEIEg6QZUZeF9LQsNIDkuR5fkXK5IVq1FVTxQ0qUZTla0FRgRAUFQVV1TICgIG1cKNwNI0%2BDoM1iAtK1CRdB0J3St1PW9GwJwDRgCGDUNxUjaNY1oeMJywFMjHTQlM2zPMC14IsSzLRNKzqcVa3rRsMFmQlW3bTs%2BB7ftBxHMd8UZfgp1EcQ5zmhcVHUcNdDONdjHJbdgkg/dD3iY9T3PS9MGvW971PJ8XyeN8TA/b9f3/HMjmA0DwPzeAIGg9g4IYxDkNQ9DMOwtjcM8fCGGcbi%2BmI6GmPIljSCohpxJR%2BiGkRkZWPqYpJPRvj8cGISZIksTYaIgZymxii5KmBSuExHExXDDStPJXT9MM4zTPgiyXnpJmbPldlOW5VzXKUzy1OAyVLD82zWSUoCvLZ%2BWlfs0DYnsSQgA%3D%3D)

I think `fmaf` is a libc function? Anyways, THIS is actually the main cause for non-FMA slowdowns:

Tested with `RUSTFLAGS="-Ctarget-cpu=native -Ctarget-feature=-fma`.

Before:
```rs
yuv 8-bit 4:4:4 full to xyb
                        time:   [5.0675 ms 5.0925 ms 5.1187 ms]

yuv 8-bit 4:2:0 full to xyb
                        time:   [4.9403 ms 4.9446 ms 4.9489 ms]

yuv 8-bit 4:2:0 limited to xyb
                        time:   [4.9657 ms 4.9698 ms 4.9748 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

yuv 10-bit 4:4:4 full to xyb
                        time:   [15.780 ms 15.842 ms 15.908 ms]
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe

yuv 10-bit 4:2:0 full to xyb
                        time:   [15.594 ms 15.612 ms 15.632 ms]
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

yuv 10-bit 4:2:0 limited to xyb
                        time:   [15.482 ms 15.569 ms 15.663 ms]
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe

rgb to lrgb via hybrid log-gamma system
                        time:   [2.6201 ms 2.6238 ms 2.6277 ms]
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe
```

After:
```rs
yuv 8-bit 4:4:4 full to xyb
                        time:   [1.6948 ms 1.7007 ms 1.7064 ms]
                        change: [-66.733% -66.546% -66.355%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking yuv 8-bit 4:2:0 full to xyb: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
yuv 8-bit 4:2:0 full to xyb
                        time:   [1.6762 ms 1.6768 ms 1.6774 ms]
                        change: [-66.124% -66.092% -66.061%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking yuv 8-bit 4:2:0 limited to xyb: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.5s, enable flat sampling, or reduce sample count to 50.
yuv 8-bit 4:2:0 limited to xyb
                        time:   [1.7152 ms 1.7178 ms 1.7197 ms]
                        change: [-65.841% -65.744% -65.660%] (p = 0.00 < 0.05)
                        Performance has improved.

yuv 10-bit 4:4:4 full to xyb
                        time:   [3.5269 ms 3.5337 ms 3.5414 ms]
                        change: [-77.797% -77.694% -77.597%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

yuv 10-bit 4:2:0 full to xyb
                        time:   [3.4447 ms 3.4582 ms 3.4715 ms]
                        change: [-77.940% -77.849% -77.754%] (p = 0.00 < 0.05)
                        Performance has improved.

yuv 10-bit 4:2:0 limited to xyb
                        time:   [3.5220 ms 3.5237 ms 3.5254 ms]
                        change: [-77.505% -77.368% -77.240%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

rgb to lrgb via hybrid log-gamma system
                        time:   [275.83 µs 275.95 µs 276.09 µs]
                        change: [-89.500% -89.484% -89.469%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```