### PR TITLE
refactor: less #[inline(always)]

### DIFF
--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -42,31 +42,31 @@ impl Hsl {
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn data(&self) -> &[[f32; 3]] {
         &self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn data_mut(&mut self) -> &mut [[f32; 3]] {
         &mut self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn into_data(self) -> Vec<[f32; 3]> {
         self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn width(&self) -> usize {
         self.width
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn height(&self) -> usize {
         self.height
     }

--- a/src/linear_rgb.rs
+++ b/src/linear_rgb.rs
@@ -39,31 +39,31 @@ impl LinearRgb {
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn data(&self) -> &[[f32; 3]] {
         &self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn data_mut(&mut self) -> &mut [[f32; 3]] {
         &mut self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn into_data(self) -> Vec<[f32; 3]> {
         self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn width(&self) -> usize {
         self.width
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn height(&self) -> usize {
         self.height
     }

--- a/src/math.rs
+++ b/src/math.rs
@@ -130,32 +130,32 @@ fn log2(x: f32) -> f32 {
     polynomial + exp
 }
 
-#[inline(always)]
+#[inline]
 fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
     multiply_add(x, poly4(x, c1, c2, c3, c4, c5), c0)
 }
 
-#[inline(always)]
+#[inline]
 fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
     multiply_add(x, poly3(x, c1, c2, c3, c4), c0)
 }
 
-#[inline(always)]
+#[inline]
 fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
     multiply_add(x, poly2(x, c1, c2, c3), c0)
 }
 
-#[inline(always)]
+#[inline]
 fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
     multiply_add(x, poly1(x, c1, c2), c0)
 }
 
-#[inline(always)]
+#[inline]
 fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
     multiply_add(x, poly0(x, c1), c0)
 }
 
-#[inline(always)]
+#[inline]
 const fn poly0(_x: f32, c0: f32) -> f32 {
     c0
 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -61,43 +61,43 @@ impl Rgb {
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn data(&self) -> &[[f32; 3]] {
         &self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn data_mut(&mut self) -> &mut [[f32; 3]] {
         &mut self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn into_data(self) -> Vec<[f32; 3]> {
         self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn width(&self) -> usize {
         self.width
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn height(&self) -> usize {
         self.height
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn transfer(&self) -> TransferCharacteristic {
         self.transfer
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn primaries(&self) -> ColorPrimaries {
         self.primaries
     }

--- a/src/xyb.rs
+++ b/src/xyb.rs
@@ -35,31 +35,31 @@ impl Xyb {
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn data(&self) -> &[[f32; 3]] {
         &self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn data_mut(&mut self) -> &mut [[f32; 3]] {
         &mut self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub fn into_data(self) -> Vec<[f32; 3]> {
         self.data
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn width(&self) -> usize {
         self.width
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn height(&self) -> usize {
         self.height
     }

--- a/src/yuv.rs
+++ b/src/yuv.rs
@@ -121,25 +121,25 @@ impl<T: Pixel> Yuv<T> {
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn data(&self) -> &[Plane<T>] {
         &self.data.planes
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn width(&self) -> usize {
         self.data.planes[0].cfg.width
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn height(&self) -> usize {
         self.data.planes[0].cfg.height
     }
 
     #[must_use]
-    #[inline(always)]
+    #[inline]
     pub const fn config(&self) -> YuvConfig {
         self.config
     }


### PR DESCRIPTION
It's a bit unnecessary to have inline(always) on getter functions IMHO. The `polyX` functions are also very small, so a normal inline attribute is enough.