### PR TITLE
Version 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 0.4.1
+
+- Improve speed of FP math on platforms without FMA at the cost of precision
+- Update v_frame dependency to 0.3.8 in order to remove unsound code
+- Increase MSRV to 1.64.0
+- Factor out math abstractions into new subcrate [`yuvxyb-math`](https://crates.io/crates/yuvxyb-math)
+- Refactor code to avoid some proc-macro dependencies
+
 ## Version 0.4.0
 
 - Optimize HLG transfer function

--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -754,7 +754,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yuvxyb"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "av-data",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yuvxyb"
 description = "Conversions between YUV (YCbCr), XYB, and other colorspaces"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MIT"
 documentation = "https://docs.rs/yuvxyb"

--- a/yuvxyb-math/CHANGELOG.md
+++ b/yuvxyb-math/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Version 0.1.0
+
+- Initial release

--- a/yuvxyb-math/README.md
+++ b/yuvxyb-math/README.md
@@ -1,0 +1,7 @@
+# yuvxyb-math
+
+[![docs.rs](https://img.shields.io/docsrs/yuvxyb-math?style=for-the-badge)](https://docs.rs/yuvxyb-math)
+[![Crates.io](https://img.shields.io/crates/v/yuvxyb-math?style=for-the-badge)](https://crates.io/crates/yuvxyb-math)
+[![LICENSE](https://img.shields.io/crates/l/yuvxyb-math?style=for-the-badge)](https://github.com/rust-av/yuvxyb/blob/main/yuvxyb-math/LICENSE)
+
+Rust crate containing helper functions and types for [yuvxyb](https://crates.io/crates/yuvxyb).


### PR DESCRIPTION
If you don't mind, I think now is a good point to release yuvxyb-math and bump yuvxyb. No breaking changes in yuvxyb (this feels surprising for some reason), so we can actually use 0.4.1 instead of 0.5.