### PR TITLE
Avoid spraying inline always everywhere

### DIFF
--- a/yuvxyb-math/src/pow_exp.rs
+++ b/yuvxyb-math/src/pow_exp.rs
@@ -70,27 +70,22 @@ fn log2(x: f32) -> f32 {
     polynomial + exp
 }
 
-#[inline]
 fn poly5(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32, c5: f32) -> f32 {
     multiply_add(x, poly4(x, c1, c2, c3, c4, c5), c0)
 }
 
-#[inline]
 fn poly4(x: f32, c0: f32, c1: f32, c2: f32, c3: f32, c4: f32) -> f32 {
     multiply_add(x, poly3(x, c1, c2, c3, c4), c0)
 }
 
-#[inline]
 fn poly3(x: f32, c0: f32, c1: f32, c2: f32, c3: f32) -> f32 {
     multiply_add(x, poly2(x, c1, c2, c3), c0)
 }
 
-#[inline]
 fn poly2(x: f32, c0: f32, c1: f32, c2: f32) -> f32 {
     multiply_add(x, poly1(x, c1, c2), c0)
 }
 
-#[inline]
 fn poly1(x: f32, c0: f32, c1: f32) -> f32 {
     multiply_add(x, poly0(x, c1), c0)
 }

--- a/yuvxyb/src/hsl.rs
+++ b/yuvxyb/src/hsl.rs
@@ -92,7 +92,6 @@ impl From<LinearRgb> for Hsl {
     }
 }
 
-#[inline(always)]
 #[allow(clippy::many_single_char_names)]
 fn lrgb_to_hsl(rgb: [f32; 3]) -> [f32; 3] {
     let x_max = rgb[0].max(rgb[1]).max(rgb[2]);

--- a/yuvxyb/src/linear_rgb.rs
+++ b/yuvxyb/src/linear_rgb.rs
@@ -137,7 +137,6 @@ impl From<Hsl> for LinearRgb {
     }
 }
 
-#[inline(always)]
 fn hsl_to_lrgb(hsl: [f32; 3]) -> [f32; 3] {
     let c = (1.0 - 2.0f32.mul_add(hsl[2], -1.0).abs()) * hsl[1];
     let h_prime = hsl[0] / 60.0;

--- a/yuvxyb/src/rgb_xyb.rs
+++ b/yuvxyb/src/rgb_xyb.rs
@@ -102,7 +102,6 @@ pub fn xyb_to_linear_rgb(mut input: Vec<[f32; 3]>) -> Vec<[f32; 3]> {
     input
 }
 
-#[inline]
 fn opsin_absorbance(rgb: &[f32; 3]) -> [f32; 3] {
     let mut out = [0.0f32; 3];
     out[0] = OPSIN_ABSORBANCE_MATRIX[0].mul_add(
@@ -129,7 +128,6 @@ fn opsin_absorbance(rgb: &[f32; 3]) -> [f32; 3] {
     out
 }
 
-#[inline]
 fn mixed_to_xyb(mixed: &[f32; 3]) -> [f32; 3] {
     let mut out = [0.0f32; 3];
     out[0] = 0.5f32 * (mixed[0] - mixed[1]);

--- a/yuvxyb/src/yuv_rgb.rs
+++ b/yuvxyb/src/yuv_rgb.rs
@@ -138,21 +138,18 @@ fn ypbpr_to_ycbcr<T: Pixel>(
     Yuv::new(output, config).unwrap()
 }
 
-#[inline(always)]
 fn to_f32_luma<T: Pixel>(val: T, scale: f32, offset: f32) -> f32 {
     // Converts to a float value in the range 0.0..=1.0
     let val = f32::from(u16::cast_from(val));
     clamp(val.mul_add(scale, offset), 0.0, 1.0)
 }
 
-#[inline(always)]
 fn to_f32_chroma<T: Pixel>(val: T, scale: f32, offset: f32) -> f32 {
     // Converts to a float value in the range -0.5..=0.5
     let val = f32::from(u16::cast_from(val));
     clamp(val.mul_add(scale, offset), -0.5, 0.5)
 }
 
-#[inline(always)]
 fn from_f32_luma<T: Pixel>(val: f32, scale: f32, offset: f32, bd: u8) -> T {
     // Converts to a float value in the range 0.0..=1.0
     T::cast_from(clamp(
@@ -162,7 +159,6 @@ fn from_f32_luma<T: Pixel>(val: f32, scale: f32, offset: f32, bd: u8) -> T {
     ))
 }
 
-#[inline(always)]
 fn from_f32_chroma<T: Pixel>(val: f32, scale: f32, offset: f32, bd: u8, full_range: bool) -> T {
     // Accounts for rounding issues
     if full_range && (val + 0.5).abs() < f32::EPSILON {

--- a/yuvxyb/src/yuv_rgb/transfer.rs
+++ b/yuvxyb/src/yuv_rgb/transfer.rs
@@ -111,7 +111,6 @@ const ST2084_OOTF_SCALE: f32 = 59.490_803;
 const ARIB_B67_A: f32 = 0.178_832_77;
 const ARIB_B67_B: f32 = 0.284_668_92;
 const ARIB_B67_C: f32 = 0.559_910_7;
-#[inline(always)]
 fn log100_oetf(x: f32) -> f32 {
     if x <= 0.01 {
         0.0
@@ -120,7 +119,6 @@ fn log100_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn log100_inverse_oetf(x: f32) -> f32 {
     if x <= 0.0 {
         0.01
@@ -129,7 +127,6 @@ fn log100_inverse_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn log316_oetf(x: f32) -> f32 {
     if x <= 0.003_162_277_6 {
         0.0
@@ -138,7 +135,6 @@ fn log316_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn log316_inverse_oetf(x: f32) -> f32 {
     if x <= 0.0 {
         0.003_162_277_6
@@ -148,7 +144,6 @@ fn log316_inverse_oetf(x: f32) -> f32 {
 }
 
 // Ignore the BT.1886 provisions for limited contrast and assume an ideal CRT.
-#[inline(always)]
 fn rec_1886_eotf(x: f32) -> f32 {
     if x <= 0.0 {
         0.0
@@ -157,7 +152,6 @@ fn rec_1886_eotf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn rec_1886_inverse_eotf(x: f32) -> f32 {
     if x <= 0.0 {
         0.0
@@ -166,7 +160,6 @@ fn rec_1886_inverse_eotf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn rec_470m_oetf(x: f32) -> f32 {
     if x <= 0.0 {
         0.0
@@ -175,7 +168,6 @@ fn rec_470m_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn rec_470m_inverse_oetf(x: f32) -> f32 {
     if x <= 0.0 {
         0.0
@@ -184,7 +176,6 @@ fn rec_470m_inverse_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn rec_470bg_oetf(x: f32) -> f32 {
     if x <= 0.0 {
         0.0
@@ -193,7 +184,6 @@ fn rec_470bg_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn rec_470bg_inverse_oetf(x: f32) -> f32 {
     if x <= 0.0 {
         0.0
@@ -202,7 +192,6 @@ fn rec_470bg_inverse_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn rec_709_oetf(x: f32) -> f32 {
     let x = x.max(0.0);
 
@@ -214,7 +203,6 @@ fn rec_709_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn rec_709_inverse_oetf(x: f32) -> f32 {
     let x = x.max(0.0);
 
@@ -225,7 +213,6 @@ fn rec_709_inverse_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn xvycc_eotf(x: f32) -> f32 {
     if (0.0..=1.0).contains(&x) {
         rec_1886_eotf(x.abs()).copysign(x)
@@ -234,7 +221,6 @@ fn xvycc_eotf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn xvycc_inverse_eotf(x: f32) -> f32 {
     if (0.0..=1.0).contains(&x) {
         rec_1886_inverse_eotf(x.abs()).copysign(x)
@@ -243,7 +229,6 @@ fn xvycc_inverse_eotf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn srgb_eotf(x: f32) -> f32 {
     let x = x.max(0.0);
 
@@ -254,7 +239,6 @@ fn srgb_eotf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn srgb_inverse_eotf(x: f32) -> f32 {
     let x = x.max(0.0);
 
@@ -266,7 +250,6 @@ fn srgb_inverse_eotf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn st_2084_inverse_eotf(x: f32) -> f32 {
     // Filter negative values to avoid NAN, and also special-case 0 so that (f(g(0))
     // == 0).
@@ -285,17 +268,14 @@ fn st_2084_inverse_eotf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn inverse_ootf_st2084(x: f32) -> f32 {
     rec_709_inverse_oetf(rec_1886_inverse_eotf(x * 100.0)) / ST2084_OOTF_SCALE
 }
 
-#[inline(always)]
 fn ootf_st2084(x: f32) -> f32 {
     rec_1886_eotf(rec_709_oetf(x * ST2084_OOTF_SCALE)) / 100.0
 }
 
-#[inline(always)]
 fn st_2084_eotf(x: f32) -> f32 {
     if x > 0.0 {
         let xpow = powf(x, 1.0 / ST2084_M2);
@@ -307,17 +287,14 @@ fn st_2084_eotf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn st_2084_inverse_oetf(x: f32) -> f32 {
     inverse_ootf_st2084(st_2084_eotf(x))
 }
 
-#[inline(always)]
 fn st_2084_oetf(x: f32) -> f32 {
     st_2084_inverse_eotf(ootf_st2084(x))
 }
 
-#[inline(always)]
 fn arib_b67_inverse_oetf(x: f32) -> f32 {
     let x = x.max(0.0);
 
@@ -328,7 +305,6 @@ fn arib_b67_inverse_oetf(x: f32) -> f32 {
     }
 }
 
-#[inline(always)]
 fn arib_b67_oetf(x: f32) -> f32 {
     let x = x.max(0.0);
 


### PR DESCRIPTION
The inline always attribute should be avoided unless thorough benchmarking has shown that it is helpful in a specific place. The original thought was that adding it would improve vectorization, but it is likely that the compiler is able to make correct decisions on its own on where to inline.

Removing these attributes seemed to show a minor (0-2%) performance improvement.

Additionally, adding the `#[inline]` attribute on a non-public function does nothing, as this hint allows functions to be inlined across crates, which means it is only useful on public functions.