### PR TITLE
ci: Use MSRV lockfile for CI testing

### DIFF
--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -26,6 +26,7 @@ jobs:
           tool: cargo-msrv
       - name: Validate minimum Rust version
         run: |
+          mv Cargo.lock.MSRV Cargo.lock
           cargo msrv verify --path yuvxyb-math
           cargo msrv verify --path yuvxyb
 


### PR DESCRIPTION
Without this, the MSRV check will always fail if any dependency releases a new, MSRV-incompatible version.