### PR TITLE
Reduce CI permissions to only read repository

### DIFF
--- a/.github/workflows/crate.yml
+++ b/.github/workflows/crate.yml
@@ -1,4 +1,6 @@
 name: Crate
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
From the code scanning advisory:

> If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.

[Docs for the `permissions` key](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions)

I think most of the rust-av CI jobs only need `contents: read`, maybe it'd make more sense to set it org-wide instead? Either way, can't hurt to specify it here