### PR TITLE
Use uninitialized buffer when converting yuv_to_rgb

### DIFF
--- a/yuvxyb/benches/benches.rs
+++ b/yuvxyb/benches/benches.rs
@@ -220,6 +220,34 @@ fn bench_rgb_to_yuv(c: &mut Criterion) {
     });
 }
 
+fn bench_yuv_8b_420_limited_to_rgb(c: &mut Criterion) {
+    c.bench_function("yuv 4:2:0 8-bit to rgb", |b| {
+        let input = make_yuv_8b(
+            (1, 1),
+            false,
+            MatrixCoefficients::BT709,
+            TransferCharacteristic::BT1886,
+            ColorPrimaries::BT709,
+        );
+
+        b.iter(|| Rgb::try_from(black_box(&input)).unwrap())
+    });
+}
+
+fn bench_yuv_10b_420_limited_to_rgb(c: &mut Criterion) {
+    c.bench_function("yuv 4:2:0 10-bit to rgb", |b| {
+        let input = make_yuv_10b(
+            (1, 1),
+            false,
+            MatrixCoefficients::BT709,
+            TransferCharacteristic::BT1886,
+            ColorPrimaries::BT709,
+        );
+
+        b.iter(|| Rgb::try_from(black_box(&input)).unwrap())
+    });
+}
+
 fn make_linear_rgb_data(count: usize) -> Vec<[f32; 3]> {
     let mut rng = rand::rng();
     (0..count)
@@ -306,6 +334,8 @@ criterion_group!(
     bench_yuv_10b_420_limited_to_xyb,
     bench_hybrid_log_gamma,
     bench_rgb_to_yuv,
+    bench_yuv_8b_420_limited_to_rgb,
+    bench_yuv_10b_420_limited_to_rgb,
     bench_linear_rgb_to_xyb_scalar,
     bench_xyb_to_linear_rgb_scalar,
 );
@@ -321,6 +351,8 @@ criterion_group!(
     bench_yuv_10b_420_limited_to_xyb,
     bench_hybrid_log_gamma,
     bench_rgb_to_yuv,
+    bench_yuv_8b_420_limited_to_rgb,
+    bench_yuv_10b_420_limited_to_rgb,
     bench_linear_rgb_to_xyb_scalar,
     bench_linear_rgb_to_xyb_simd_x8,
     bench_linear_rgb_to_xyb_simd_x16,

--- a/yuvxyb/src/yuv_rgb/mod.rs
+++ b/yuvxyb/src/yuv_rgb/mod.rs
@@ -53,7 +53,10 @@ fn ycbcr_to_ypbpr<T: Pixel>(input: &Yuv<T>) -> Vec<[f32; 3]> {
     let y_origin = &y_plane.data()[y_origin..];
     let u_origin = &u_plane.data()[u_origin..];
     let v_origin = &v_plane.data()[v_origin..];
-    let mut output = vec![[0.0, 0.0, 0.0]; w * h];
+
+    // Empty, but with enough capacity
+    let mut output = Vec::with_capacity(w * h);
+    let uninit_output = output.spare_capacity_mut();
     for y in 0..h {
         for x in 0..w {
             let output_pos = y * w + x;
@@ -62,14 +65,18 @@ fn ycbcr_to_ypbpr<T: Pixel>(input: &Yuv<T>) -> Vec<[f32; 3]> {
             let v_pos = (y >> ss_y) * v_stride + (x >> ss_x);
             // SAFETY: The bounds of the YUV data are validated when we construct it.
             unsafe {
-                *output.get_unchecked_mut(output_pos) = [
+                uninit_output.get_unchecked_mut(output_pos).write([
                     to_f32_luma(*y_origin.get_unchecked(y_pos), luma_scale, luma_offset),
                     to_f32_chroma(*u_origin.get_unchecked(u_pos), chroma_scale, chroma_offset),
                     to_f32_chroma(*v_origin.get_unchecked(v_pos), chroma_scale, chroma_offset),
-                ];
+                ]);
             }
         }
     }
+    // SAFETY:
+    // - Ensured enough capacity in Vec::with_capacity
+    // - Initialized everything from 0..w * h in the loop
+    unsafe { output.set_len(w * h) };
     output
 }
 


### PR DESCRIPTION
[The `spare_capacity_mut` docs](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.spare_capacity_mut) show that this is one (the?) intended way of doing uninitialized memory in a Vec.

New benches show around 5-7% speedup for the Yuv->Rgb step for me.