### PR TITLE
v_frame 0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ as well as all widely-used matrix coefficients and transfer characteristics.
 
 ## Minimum supported Rust version (MSRV)
 
-This crate requires a Rust version of 1.89.0 or higher. Increases in MSRV will result in a semver PATCH version increase.
+This crate requires a Rust version of 1.95.0 or higher. Increases in MSRV will result in a semver PATCH version increase.

--- a/yuvxyb/Cargo.toml
+++ b/yuvxyb/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/rust-av/yuvxyb"
 repository = "https://github.com/rust-av/yuvxyb"
 exclude = ["test_data", "yuvxyb-dump"]
 
-rust-version = "1.89.0"
+rust-version = "1.95.0"
 
 [features]
 default = ["fastmath", "simd"]
@@ -21,7 +21,7 @@ yuvxyb-math = { version = "0.1.1", path = "../yuvxyb-math" }
 av-data = "0.4.2"
 log = "0.4.17"
 num-traits = "0.2.15"
-v_frame = { version = "0.5.1", features = ["padding_api"] }
+v_frame = { version = "0.7", features = ["padding_api"] }
 wide = { version = "1.1", optional = true }
 
 [dev-dependencies]

--- a/yuvxyb/Cargo.toml
+++ b/yuvxyb/Cargo.toml
@@ -20,7 +20,6 @@ simd = ["yuvxyb-math/simd", "wide"]
 yuvxyb-math = { version = "0.1.1", path = "../yuvxyb-math" }
 av-data = "0.4.2"
 log = "0.4.17"
-num-traits = "0.2.15"
 v_frame = { version = "0.7", features = ["padding_api"] }
 wide = { version = "1.1", optional = true }
 

--- a/yuvxyb/README.md
+++ b/yuvxyb/README.md
@@ -10,4 +10,4 @@ as well as all widely-used matrix coefficients and transfer characteristics.
 
 ## Minimum supported Rust version (MSRV)
 
-This crate requires a Rust version of 1.89.0 or higher. Increases in MSRV will result in a semver PATCH version increase.
+This crate requires a Rust version of 1.95.0 or higher. Increases in MSRV will result in a semver PATCH version increase.

--- a/yuvxyb/benches/benches.rs
+++ b/yuvxyb/benches/benches.rs
@@ -88,6 +88,26 @@ fn make_yuv_10b(
     .unwrap()
 }
 
+fn make_rgb(width: usize, height: usize) -> Rgb {
+    let len = width * height;
+    let mut data = vec![[0f32; 3]; len];
+
+    let mut rng = rand::rng();
+
+    for pix in &mut data {
+        *pix = rng.random();
+    }
+
+    Rgb::new(
+        data,
+        width,
+        height,
+        TransferCharacteristic::BT1886,
+        ColorPrimaries::BT709,
+    )
+    .expect("can build Rgb")
+}
+
 fn bench_yuv_8b_444_full_to_xyb(c: &mut Criterion) {
     c.bench_function("yuv 8-bit 4:4:4 full to xyb", |b| {
         let input = make_yuv_8b(
@@ -183,6 +203,23 @@ fn bench_hybrid_log_gamma(c: &mut Criterion) {
     });
 }
 
+fn bench_rgb_to_yuv(c: &mut Criterion) {
+    c.bench_function("rgb to yuv 4:2:0 8-bit full", |b| {
+        let input = make_rgb(320, 240);
+        let config = YuvConfig {
+            bit_depth: 8,
+            subsampling_x: 1,
+            subsampling_y: 1,
+            full_range: true,
+            matrix_coefficients: MatrixCoefficients::BT709,
+            transfer_characteristics: TransferCharacteristic::BT1886,
+            color_primaries: ColorPrimaries::BT709,
+        };
+
+        b.iter(|| Yuv::<u8>::try_from((black_box(&input), config)));
+    });
+}
+
 fn make_linear_rgb_data(count: usize) -> Vec<[f32; 3]> {
     let mut rng = rand::rng();
     (0..count)
@@ -268,6 +305,7 @@ criterion_group!(
     bench_yuv_10b_420_full_to_xyb,
     bench_yuv_10b_420_limited_to_xyb,
     bench_hybrid_log_gamma,
+    bench_rgb_to_yuv,
     bench_linear_rgb_to_xyb_scalar,
     bench_xyb_to_linear_rgb_scalar,
 );
@@ -282,6 +320,7 @@ criterion_group!(
     bench_yuv_10b_420_full_to_xyb,
     bench_yuv_10b_420_limited_to_xyb,
     bench_hybrid_log_gamma,
+    bench_rgb_to_yuv,
     bench_linear_rgb_to_xyb_scalar,
     bench_linear_rgb_to_xyb_simd_x8,
     bench_linear_rgb_to_xyb_simd_x16,

--- a/yuvxyb/benches/benches.rs
+++ b/yuvxyb/benches/benches.rs
@@ -1,5 +1,5 @@
 use std::hint::black_box;
-use std::num::{NonZeroU8, NonZeroUsize};
+use std::num::NonZeroUsize;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::RngExt;
@@ -18,14 +18,7 @@ fn make_yuv_8b(
         (0, 0) => ChromaSubsampling::Yuv444,
         _ => unreachable!(),
     };
-    let mut data: Frame<u8> = FrameBuilder::new(
-        NonZeroUsize::new(320).unwrap(),
-        NonZeroUsize::new(240).unwrap(),
-        chroma,
-        NonZeroU8::new(8).unwrap(),
-    )
-    .build()
-    .unwrap();
+    let mut data: Frame<u8> = FrameBuilder::new(320, 240, chroma, 8).build().unwrap();
     let mut rng = rand::rng();
     for i in 0..3 {
         let plane = data.plane_mut(i).unwrap();
@@ -67,14 +60,7 @@ fn make_yuv_10b(
         (0, 0) => ChromaSubsampling::Yuv444,
         _ => unreachable!(),
     };
-    let mut data: Frame<u16> = FrameBuilder::new(
-        NonZeroUsize::new(320).unwrap(),
-        NonZeroUsize::new(240).unwrap(),
-        chroma,
-        NonZeroU8::new(10).unwrap(),
-    )
-    .build()
-    .unwrap();
+    let mut data: Frame<u16> = FrameBuilder::new(320, 240, chroma, 10).build().unwrap();
     let mut rng = rand::rng();
     for i in 0..3 {
         let plane = data.plane_mut(i).unwrap();

--- a/yuvxyb/benches/benches.rs
+++ b/yuvxyb/benches/benches.rs
@@ -1,5 +1,4 @@
 use std::hint::black_box;
-use std::num::NonZeroUsize;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use rand::RngExt;

--- a/yuvxyb/src/errors.rs
+++ b/yuvxyb/src/errors.rs
@@ -54,11 +54,7 @@ impl fmt::Display for ConversionError {
 ///
 /// // 10 pixels is not enough for the resolution 1920x1080
 /// let float_data = vec![[0f32; 3]; 10];
-/// let result = LinearRgb::new(
-///     float_data,
-///     NonZeroUsize::new(1920).unwrap(),
-///     NonZeroUsize::new(1080).unwrap(),
-/// );
+/// let result = LinearRgb::new(float_data, 1920, 1080);
 ///
 /// assert!(result.is_err());
 /// assert_eq!(result.unwrap_err(), CreationError::ResolutionMismatch);
@@ -68,6 +64,9 @@ impl fmt::Display for ConversionError {
 /// [`YuvError`]: crate::yuv::YuvError
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CreationError {
+    /// The supplied width and/or height is zero, which is unsupported.
+    ZeroResolution,
+
     /// There is a mismatch between the supplied data and the supplied resolution.
     ///
     /// Generally, data.len() should be equal to width * height.
@@ -79,6 +78,9 @@ impl std::error::Error for CreationError {}
 impl fmt::Display for CreationError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            Self::ZeroResolution => {
+                write!(f, "The supplied width or height is zero.")
+            }
             Self::ResolutionMismatch => {
                 write!(f, "Data length does not match the specified dimensions.")
             }

--- a/yuvxyb/src/errors.rs
+++ b/yuvxyb/src/errors.rs
@@ -87,3 +87,40 @@ impl fmt::Display for CreationError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Just make sure formatting doesn't panic and returns a non-empty message.
+
+    #[test]
+    fn conversion_error_fmt() {
+        let errors = &[
+            ConversionError::UnsupportedMatrixCoefficients,
+            ConversionError::UnspecifiedMatrixCoefficients,
+            ConversionError::UnsupportedColorPrimaries,
+            ConversionError::UnspecifiedColorPrimaries,
+            ConversionError::UnsupportedTransferCharacteristic,
+            ConversionError::UnspecifiedTransferCharacteristic,
+        ];
+
+        for err in errors {
+            let msg = format!("{err}");
+            assert!(!msg.is_empty());
+        }
+    }
+
+    #[test]
+    fn creation_error_fmt() {
+        let errors = &[
+            CreationError::ZeroResolution,
+            CreationError::ResolutionMismatch,
+        ];
+
+        for err in errors {
+            let msg = format!("{err}");
+            assert!(!msg.is_empty());
+        }
+    }
+}

--- a/yuvxyb/src/hsl/mod.rs
+++ b/yuvxyb/src/hsl/mod.rs
@@ -34,11 +34,15 @@ impl Hsl {
     ///
     /// # Errors
     /// - If data length does not match `width * height`
-    pub fn new(
-        data: Vec<[f32; 3]>,
-        width: NonZeroUsize,
-        height: NonZeroUsize,
-    ) -> Result<Self, CreationError> {
+    pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self, CreationError> {
+        let Some(width) = NonZeroUsize::new(width) else {
+            return Err(CreationError::ZeroResolution);
+        };
+
+        let Some(height) = NonZeroUsize::new(height) else {
+            return Err(CreationError::ZeroResolution);
+        };
+
         if data.len() != width.saturating_mul(height).get() {
             return Err(CreationError::ResolutionMismatch);
         }
@@ -68,23 +72,25 @@ impl Hsl {
         self.data
     }
 
+    /// Guaranteed to be non-zero.
     #[must_use]
     #[inline]
-    pub const fn width(&self) -> NonZeroUsize {
-        self.width
+    pub const fn width(&self) -> usize {
+        self.width.get()
     }
 
+    /// Guaranteed to be non-zero.
     #[must_use]
     #[inline]
-    pub const fn height(&self) -> NonZeroUsize {
-        self.height
+    pub const fn height(&self) -> usize {
+        self.height.get()
     }
 }
 
 impl From<LinearRgb> for Hsl {
     fn from(lrgb: LinearRgb) -> Self {
-        let width = lrgb.width();
-        let height = lrgb.height();
+        let width = NonZeroUsize::new(lrgb.width()).expect("is non-zero");
+        let height = NonZeroUsize::new(lrgb.height()).expect("is non-zero");
         let mut data = lrgb.into_data();
         for pix in &mut data {
             *pix = lrgb_to_hsl(*pix);

--- a/yuvxyb/src/hsl/mod.rs
+++ b/yuvxyb/src/hsl/mod.rs
@@ -33,6 +33,7 @@ impl Hsl {
     /// Create a new [`Hsl`] with the given data, width and height.
     ///
     /// # Errors
+    /// - If `width` or `height` are zero
     /// - If data length does not match `width * height`
     pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self, CreationError> {
         let Some(width) = NonZeroUsize::new(width) else {

--- a/yuvxyb/src/hsl/tests.rs
+++ b/yuvxyb/src/hsl/tests.rs
@@ -1,6 +1,33 @@
 use super::*;
 
 #[test]
+fn hsl_new_zero_res() {
+    assert!(matches!(
+        Hsl::new(vec![], 0, 1),
+        Err(CreationError::ZeroResolution)
+    ));
+
+    assert!(matches!(
+        Hsl::new(vec![], 1, 0),
+        Err(CreationError::ZeroResolution)
+    ));
+}
+
+#[test]
+fn hsl_new_res_mismatch() {
+    assert!(matches!(
+        Hsl::new(vec![], 320, 240),
+        Err(CreationError::ResolutionMismatch)
+    ));
+}
+
+#[test]
+fn hsl_new_ok() {
+    let data = vec![[1., 1., 1.]; 4];
+    assert!(Hsl::new(data, 2, 2).is_ok())
+}
+
+#[test]
 fn test_black() {
     let result = lrgb_to_hsl([0.0, 0.0, 0.0]);
     assert!((result[0] - 0.0).abs() < f32::EPSILON); // H
@@ -46,4 +73,17 @@ fn test_gray() {
     assert!((result[0] - 0.0).abs() < f32::EPSILON); // H
     assert!((result[1] - 0.0).abs() < f32::EPSILON); // S
     assert!((result[2] - 0.5).abs() < f32::EPSILON); // L
+}
+
+#[test]
+fn test_gray_through_from_trait() {
+    let data = vec![[0.5, 0.5, 0.5]; 16];
+    let linear_rgb = LinearRgb::new(data, 4, 4).unwrap();
+
+    let hsl = Hsl::from(linear_rgb);
+    for [h, s, l] in hsl.data() {
+        assert!((h - 0.0).abs() < f32::EPSILON);
+        assert!((s - 0.0).abs() < f32::EPSILON);
+        assert!((l - 0.5).abs() < f32::EPSILON);
+    }
 }

--- a/yuvxyb/src/lib.rs
+++ b/yuvxyb/src/lib.rs
@@ -18,7 +18,6 @@ pub use crate::rgb::Rgb;
 pub use crate::xyb::Xyb;
 pub use crate::yuv::{Yuv, YuvConfig, YuvError};
 pub use av_data::pixel::{ColorPrimaries, MatrixCoefficients, TransferCharacteristic};
-pub use num_traits::{FromPrimitive, ToPrimitive};
 pub use v_frame::{
     chroma::ChromaSubsampling,
     frame::{Frame, FrameBuilder},

--- a/yuvxyb/src/linear_rgb/mod.rs
+++ b/yuvxyb/src/linear_rgb/mod.rs
@@ -31,11 +31,15 @@ impl LinearRgb {
     ///
     /// # Errors
     /// - If data length does not match `width * height`
-    pub fn new(
-        data: Vec<[f32; 3]>,
-        width: NonZeroUsize,
-        height: NonZeroUsize,
-    ) -> Result<Self, CreationError> {
+    pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self, CreationError> {
+        let Some(width) = NonZeroUsize::new(width) else {
+            return Err(CreationError::ZeroResolution);
+        };
+
+        let Some(height) = NonZeroUsize::new(height) else {
+            return Err(CreationError::ZeroResolution);
+        };
+
         if data.len() != width.saturating_mul(height).get() {
             return Err(CreationError::ResolutionMismatch);
         }
@@ -65,16 +69,18 @@ impl LinearRgb {
         self.data
     }
 
+    /// Guaranteed to be non-zero.
     #[must_use]
     #[inline]
-    pub const fn width(&self) -> NonZeroUsize {
-        self.width
+    pub const fn width(&self) -> usize {
+        self.width.get()
     }
 
+    /// Guaranteed to be non-zero.
     #[must_use]
     #[inline]
-    pub const fn height(&self) -> NonZeroUsize {
-        self.height
+    pub const fn height(&self) -> usize {
+        self.height.get()
     }
 }
 
@@ -99,8 +105,8 @@ impl TryFrom<Rgb> for LinearRgb {
     type Error = ConversionError;
 
     fn try_from(rgb: Rgb) -> Result<Self, Self::Error> {
-        let width = rgb.width();
-        let height = rgb.height();
+        let width = NonZeroUsize::new(rgb.width()).expect("is non-zero");
+        let height = NonZeroUsize::new(rgb.height()).expect("is non-zero");
         let transfer = rgb.transfer();
         let primaries = rgb.primaries();
 
@@ -131,8 +137,8 @@ impl From<Xyb> for LinearRgb {
 
 impl From<Hsl> for LinearRgb {
     fn from(hsl: Hsl) -> Self {
-        let width = hsl.width();
-        let height = hsl.height();
+        let width = NonZeroUsize::new(hsl.width()).expect("is non-zero");
+        let height = NonZeroUsize::new(hsl.height()).expect("is non-zero");
         let mut data = hsl.into_data();
         for pix in &mut data {
             *pix = hsl_to_lrgb(*pix);

--- a/yuvxyb/src/linear_rgb/mod.rs
+++ b/yuvxyb/src/linear_rgb/mod.rs
@@ -30,6 +30,7 @@ impl LinearRgb {
     /// Create a new [`LinearRgb`] with the given data, width and height.
     ///
     /// # Errors
+    /// - If `width` or `height` are zero
     /// - If data length does not match `width * height`
     pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self, CreationError> {
         let Some(width) = NonZeroUsize::new(width) else {

--- a/yuvxyb/src/linear_rgb/tests.rs
+++ b/yuvxyb/src/linear_rgb/tests.rs
@@ -1,5 +1,32 @@
 use super::*;
 
+#[test]
+fn linear_rgb_new_zero_res() {
+    assert!(matches!(
+        LinearRgb::new(vec![], 0, 1),
+        Err(CreationError::ZeroResolution)
+    ));
+
+    assert!(matches!(
+        LinearRgb::new(vec![], 1, 0),
+        Err(CreationError::ZeroResolution)
+    ));
+}
+
+#[test]
+fn linear_rgb_new_res_mismatch() {
+    assert!(matches!(
+        LinearRgb::new(vec![], 320, 240),
+        Err(CreationError::ResolutionMismatch)
+    ));
+}
+
+#[test]
+fn linear_rgb_new_ok() {
+    let data = vec![[1., 1., 1.]; 4];
+    assert!(LinearRgb::new(data, 2, 2).is_ok())
+}
+
 const TOLERANCE: f32 = 1e-5;
 
 fn assert_close(actual: [f32; 3], expected: [f32; 3], description: &str) {

--- a/yuvxyb/src/linear_rgb/tests.rs
+++ b/yuvxyb/src/linear_rgb/tests.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroUsize;
-
 use super::*;
 
 const TOLERANCE: f32 = 1e-5;
@@ -21,12 +19,7 @@ fn assert_close(actual: [f32; 3], expected: [f32; 3], description: &str) {
 fn test_hsl_to_linear_rgb_black() {
     // HSL: Hue=0°, Saturation=0%, Lightness=0% -> Linear RGB: (0, 0, 0)
     let hsl_data = vec![[0.0, 0.0, 0.0]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -38,12 +31,7 @@ fn test_hsl_to_linear_rgb_black() {
 fn test_hsl_to_linear_rgb_white() {
     // HSL: Hue=0°, Saturation=0%, Lightness=100% -> Linear RGB: (1, 1, 1)
     let hsl_data = vec![[0.0, 0.0, 1.0]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -55,12 +43,7 @@ fn test_hsl_to_linear_rgb_white() {
 fn test_hsl_to_linear_rgb_red() {
     // HSL: Hue=0°, Saturation=100%, Lightness=50% -> Linear RGB: (1, 0, 0)
     let hsl_data = vec![[0.0, 1.0, 0.5]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -72,12 +55,7 @@ fn test_hsl_to_linear_rgb_red() {
 fn test_hsl_to_linear_rgb_green() {
     // HSL: Hue=120°, Saturation=100%, Lightness=50% -> Linear RGB: (0, 1, 0)
     let hsl_data = vec![[120.0, 1.0, 0.5]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -89,12 +67,7 @@ fn test_hsl_to_linear_rgb_green() {
 fn test_hsl_to_linear_rgb_blue() {
     // HSL: Hue=240°, Saturation=100%, Lightness=50% -> Linear RGB: (0, 0, 1)
     let hsl_data = vec![[240.0, 1.0, 0.5]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -106,12 +79,7 @@ fn test_hsl_to_linear_rgb_blue() {
 fn test_hsl_to_linear_rgb_cyan() {
     // HSL: Hue=180°, Saturation=100%, Lightness=50% -> Linear RGB: (0, 1, 1)
     let hsl_data = vec![[180.0, 1.0, 0.5]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -123,12 +91,7 @@ fn test_hsl_to_linear_rgb_cyan() {
 fn test_hsl_to_linear_rgb_magenta() {
     // HSL: Hue=300°, Saturation=100%, Lightness=50% -> Linear RGB: (1, 0, 1)
     let hsl_data = vec![[300.0, 1.0, 0.5]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -140,12 +103,7 @@ fn test_hsl_to_linear_rgb_magenta() {
 fn test_hsl_to_linear_rgb_yellow() {
     // HSL: Hue=60°, Saturation=100%, Lightness=50% -> Linear RGB: (1, 1, 0)
     let hsl_data = vec![[60.0, 1.0, 0.5]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -157,12 +115,7 @@ fn test_hsl_to_linear_rgb_yellow() {
 fn test_hsl_to_linear_rgb_gray() {
     // HSL: Hue=any, Saturation=0%, Lightness=50% -> Linear RGB: (0.5, 0.5, 0.5)
     let hsl_data = vec![[180.0, 0.0, 0.5]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -174,12 +127,7 @@ fn test_hsl_to_linear_rgb_gray() {
 fn test_hsl_to_linear_rgb_partial_saturation() {
     // HSL: Hue=120°, Saturation=50%, Lightness=50% -> Linear RGB: (0.25, 0.75, 0.25)
     let hsl_data = vec![[120.0, 0.5, 0.5]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -191,12 +139,7 @@ fn test_hsl_to_linear_rgb_partial_saturation() {
 fn test_hsl_to_linear_rgb_low_lightness() {
     // HSL: Hue=0°, Saturation=100%, Lightness=25% -> Linear RGB: (0.5, 0, 0)
     let hsl_data = vec![[0.0, 1.0, 0.25]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -208,12 +151,7 @@ fn test_hsl_to_linear_rgb_low_lightness() {
 fn test_hsl_to_linear_rgb_high_lightness() {
     // HSL: Hue=0°, Saturation=100%, Lightness=75% -> Linear RGB: (1, 0.5, 0.5)
     let hsl_data = vec![[0.0, 1.0, 0.75]];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(1).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let result = linear_rgb.data()[0];
@@ -286,12 +224,7 @@ fn test_hsl_to_linear_rgb_edge_hue_values() {
 
     for (hsl_values, expected_rgb, description) in test_cases {
         let hsl_data = vec![hsl_values];
-        let hsl = Hsl::new(
-            hsl_data,
-            NonZeroUsize::new(1).unwrap(),
-            NonZeroUsize::new(1).unwrap(),
-        )
-        .unwrap();
+        let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
         let linear_rgb = LinearRgb::from(hsl);
 
         let result = linear_rgb.data()[0];
@@ -309,12 +242,7 @@ fn test_hsl_to_linear_rgb_multiple_pixels() {
         [120.0, 1.0, 0.5], // Green
         [240.0, 1.0, 0.5], // Blue
     ];
-    let hsl = Hsl::new(
-        hsl_data,
-        NonZeroUsize::new(5).unwrap(),
-        NonZeroUsize::new(1).unwrap(),
-    )
-    .unwrap();
+    let hsl = Hsl::new(hsl_data, 5, 1).unwrap();
     let linear_rgb = LinearRgb::from(hsl);
 
     let expected_results = [
@@ -331,8 +259,8 @@ fn test_hsl_to_linear_rgb_multiple_pixels() {
     }
 
     // Verify dimensions are preserved
-    assert_eq!(linear_rgb.width(), NonZeroUsize::new(5).unwrap());
-    assert_eq!(linear_rgb.height(), NonZeroUsize::new(1).unwrap());
+    assert_eq!(linear_rgb.width(), 5);
+    assert_eq!(linear_rgb.height(), 1);
 }
 
 #[test]
@@ -347,12 +275,7 @@ fn test_hsl_to_linear_rgb_zero_saturation() {
 
     for (hsl_values, expected_rgb) in test_cases {
         let hsl_data = vec![hsl_values];
-        let hsl = Hsl::new(
-            hsl_data,
-            NonZeroUsize::new(1).unwrap(),
-            NonZeroUsize::new(1).unwrap(),
-        )
-        .unwrap();
+        let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
         let linear_rgb = LinearRgb::from(hsl);
 
         let result = linear_rgb.data()[0];
@@ -380,12 +303,7 @@ fn test_hsl_to_linear_rgb_boundary_lightness() {
 
     for (hsl_values, expected_rgb) in test_cases {
         let hsl_data = vec![hsl_values];
-        let hsl = Hsl::new(
-            hsl_data,
-            NonZeroUsize::new(1).unwrap(),
-            NonZeroUsize::new(1).unwrap(),
-        )
-        .unwrap();
+        let hsl = Hsl::new(hsl_data, 1, 1).unwrap();
         let linear_rgb = LinearRgb::from(hsl);
 
         let result = linear_rgb.data()[0];

--- a/yuvxyb/src/rgb.rs
+++ b/yuvxyb/src/rgb.rs
@@ -28,6 +28,7 @@ impl Rgb {
     /// color primaries are correct for the data.
     ///
     /// # Errors
+    /// - If `width` or `height` are zero
     /// - If data length does not match `width * height`
     pub fn new(
         data: Vec<[f32; 3]>,

--- a/yuvxyb/src/rgb.rs
+++ b/yuvxyb/src/rgb.rs
@@ -31,11 +31,19 @@ impl Rgb {
     /// - If data length does not match `width * height`
     pub fn new(
         data: Vec<[f32; 3]>,
-        width: NonZeroUsize,
-        height: NonZeroUsize,
+        width: usize,
+        height: usize,
         mut transfer: TransferCharacteristic,
         mut primaries: ColorPrimaries,
     ) -> Result<Self, CreationError> {
+        let Some(width) = NonZeroUsize::new(width) else {
+            return Err(CreationError::ZeroResolution);
+        };
+
+        let Some(height) = NonZeroUsize::new(height) else {
+            return Err(CreationError::ZeroResolution);
+        };
+
         if data.len() != width.saturating_mul(height).get() {
             return Err(CreationError::ResolutionMismatch);
         }
@@ -80,16 +88,18 @@ impl Rgb {
         self.data
     }
 
+    /// Guaranteed to be non-zero.
     #[must_use]
     #[inline]
-    pub const fn width(&self) -> NonZeroUsize {
-        self.width
+    pub const fn width(&self) -> usize {
+        self.width.get()
     }
 
+    /// Guaranteed to be non-zero.
     #[must_use]
     #[inline]
-    pub const fn height(&self) -> NonZeroUsize {
-        self.height
+    pub const fn height(&self) -> usize {
+        self.height.get()
     }
 
     #[must_use]
@@ -121,8 +131,8 @@ impl<T: Pixel> TryFrom<&Yuv<T>> for Rgb {
 
         Ok(Self {
             data,
-            width: yuv.width(),
-            height: yuv.height(),
+            width: NonZeroUsize::new(yuv.width()).expect("is non-zero1"),
+            height: NonZeroUsize::new(yuv.height()).expect("is non-zero2"),
             transfer: yuv.config().transfer_characteristics,
             primaries: yuv.config().color_primaries,
         })
@@ -160,8 +170,8 @@ impl TryFrom<(LinearRgb, TransferCharacteristic, ColorPrimaries)> for Rgb {
             log::warn!("Color primaries not specified. Guessing {}", primaries);
         }
 
-        let width = lrgb.width();
-        let height = lrgb.height();
+        let width = NonZeroUsize::new(lrgb.width()).expect("is non-zero");
+        let height = NonZeroUsize::new(lrgb.height()).expect("is non-zero");
         let data = transform_primaries(lrgb.into_data(), ColorPrimaries::BT709, primaries)?;
         let data = transfer.to_gamma(data)?;
 

--- a/yuvxyb/src/rgb/mod.rs
+++ b/yuvxyb/src/rgb/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use std::num::NonZeroUsize;
 
 use av_data::pixel::{ColorPrimaries, TransferCharacteristic};

--- a/yuvxyb/src/rgb/tests.rs
+++ b/yuvxyb/src/rgb/tests.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+use ColorPrimaries as CP;
+use TransferCharacteristic as TC;
+
+#[test]
+fn rgb_new_zero_res() {
+    assert!(matches!(
+        Rgb::new(vec![], 0, 1, TC::SRGB, CP::BT709),
+        Err(CreationError::ZeroResolution)
+    ));
+
+    assert!(matches!(
+        Rgb::new(vec![], 1, 0, TC::SRGB, CP::BT709),
+        Err(CreationError::ZeroResolution)
+    ));
+}
+
+#[test]
+fn rgb_new_res_mismatch() {
+    assert!(matches!(
+        Rgb::new(vec![], 320, 240, TC::SRGB, CP::BT709),
+        Err(CreationError::ResolutionMismatch)
+    ));
+}
+
+#[test]
+fn rgb_new_ok() {
+    let data = vec![[1., 1., 1.]; 4];
+    assert!(Rgb::new(data, 2, 2, TC::BT1886, CP::BT709).is_ok());
+}
+
+#[test]
+fn rgb_new_fix_unspecified() {
+    let data = vec![[1., 1., 1.]; 4];
+    let rgb = Rgb::new(data, 2, 2, TC::Unspecified, CP::Unspecified).unwrap();
+
+    assert_ne!(rgb.transfer, TC::Unspecified);
+    assert_ne!(rgb.primaries, CP::Unspecified);
+}

--- a/yuvxyb/src/rgb_xyb/tests.rs
+++ b/yuvxyb/src/rgb_xyb/tests.rs
@@ -1,6 +1,5 @@
 use std::{
     fs,
-    num::NonZeroUsize,
     path::{Path, PathBuf},
 };
 
@@ -38,8 +37,8 @@ fn rgb_to_xyb_correct() {
         .collect::<Vec<_>>();
     let source = Rgb::new(
         source_data,
-        NonZeroUsize::new(1448).unwrap(),
-        NonZeroUsize::new(1080).unwrap(),
+        1448,
+        1080,
         TransferCharacteristic::SRGB,
         ColorPrimaries::BT709,
     )
@@ -78,12 +77,7 @@ fn xyb_to_rgb_correct() {
         .join("test_data")
         .join("tank_srgb.png");
     let source_data = parse_xyb_txt(&source_path);
-    let source = Xyb::new(
-        source_data,
-        NonZeroUsize::new(1448).unwrap(),
-        NonZeroUsize::new(1080).unwrap(),
-    )
-    .unwrap();
+    let source = Xyb::new(source_data, 1448, 1080).unwrap();
     let expected = image::open(expected_path).unwrap();
 
     // Fixing this would result in worse code, and this

--- a/yuvxyb/src/tests.rs
+++ b/yuvxyb/src/tests.rs
@@ -1,5 +1,3 @@
-use std::num::{NonZeroU8, NonZeroUsize};
-
 use interpolate_name::interpolate_test;
 use rand::RngExt;
 use v_frame::chroma::ChromaSubsampling;
@@ -30,14 +28,7 @@ fn yuv_xyb_yuv_ident_8b(
         (0, 0) => ChromaSubsampling::Yuv444,
         _ => unreachable!(),
     };
-    let mut data: Frame<u8> = FrameBuilder::new(
-        NonZeroUsize::new(320).unwrap(),
-        NonZeroUsize::new(240).unwrap(),
-        chroma,
-        NonZeroU8::new(8).unwrap(),
-    )
-    .build()
-    .unwrap();
+    let mut data: Frame<u8> = FrameBuilder::new(320, 240, chroma, 8).build().unwrap();
     let mut rng = rand::rng();
     for i in 0..3 {
         let plane = data.plane_mut(i).unwrap();
@@ -185,14 +176,7 @@ fn yuv_xyb_yuv_ident_10b(
         (0, 0) => ChromaSubsampling::Yuv444,
         _ => unreachable!(),
     };
-    let mut data: Frame<u16> = FrameBuilder::new(
-        NonZeroUsize::new(320).unwrap(),
-        NonZeroUsize::new(240).unwrap(),
-        chroma,
-        NonZeroU8::new(10).unwrap(),
-    )
-    .build()
-    .unwrap();
+    let mut data: Frame<u16> = FrameBuilder::new(320, 240, chroma, 10).build().unwrap();
     let mut rng = rand::rng();
     for i in 0..3 {
         let plane = data.plane_mut(i).unwrap();

--- a/yuvxyb/src/xyb.rs
+++ b/yuvxyb/src/xyb.rs
@@ -23,6 +23,7 @@ impl Xyb {
     /// Create a new [`Xyb`] with the given data, width and height.
     ///
     /// # Errors
+    /// - If `width` or `height` are zero
     /// - If data length does not match `width * height`
     pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self, CreationError> {
         let Some(width) = NonZeroUsize::new(width) else {

--- a/yuvxyb/src/xyb.rs
+++ b/yuvxyb/src/xyb.rs
@@ -24,11 +24,15 @@ impl Xyb {
     ///
     /// # Errors
     /// - If data length does not match `width * height`
-    pub fn new(
-        data: Vec<[f32; 3]>,
-        width: NonZeroUsize,
-        height: NonZeroUsize,
-    ) -> Result<Self, CreationError> {
+    pub fn new(data: Vec<[f32; 3]>, width: usize, height: usize) -> Result<Self, CreationError> {
+        let Some(width) = NonZeroUsize::new(width) else {
+            return Err(CreationError::ZeroResolution);
+        };
+
+        let Some(height) = NonZeroUsize::new(height) else {
+            return Err(CreationError::ZeroResolution);
+        };
+
         if data.len() != width.saturating_mul(height).get() {
             return Err(CreationError::ResolutionMismatch);
         }
@@ -99,8 +103,8 @@ impl TryFrom<Rgb> for Xyb {
 
 impl From<LinearRgb> for Xyb {
     fn from(lrgb: LinearRgb) -> Self {
-        let width = lrgb.width();
-        let height = lrgb.height();
+        let width = NonZeroUsize::new(lrgb.width()).expect("is non-zero");
+        let height = NonZeroUsize::new(lrgb.height()).expect("is non-zero");
         let data = linear_rgb_to_xyb(lrgb.into_data());
 
         Self {

--- a/yuvxyb/src/xyb/mod.rs
+++ b/yuvxyb/src/xyb/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use std::num::NonZeroUsize;
 
 use v_frame::pixel::Pixel;

--- a/yuvxyb/src/xyb/tests.rs
+++ b/yuvxyb/src/xyb/tests.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+#[test]
+fn xyb_new_zero_res() {
+    assert!(matches!(
+        Xyb::new(vec![], 0, 1),
+        Err(CreationError::ZeroResolution)
+    ));
+
+    assert!(matches!(
+        Xyb::new(vec![], 1, 0),
+        Err(CreationError::ZeroResolution)
+    ));
+}
+
+#[test]
+fn xyb_new_res_mismatch() {
+    assert!(matches!(
+        Xyb::new(vec![], 320, 240),
+        Err(CreationError::ResolutionMismatch)
+    ));
+}
+
+#[test]
+fn xyb_new_ok() {
+    let data = vec![[1., 1., 1.]; 4];
+    assert!(Xyb::new(data, 2, 2).is_ok())
+}

--- a/yuvxyb/src/yuv.rs
+++ b/yuvxyb/src/yuv.rs
@@ -276,3 +276,98 @@ fn guess_color_primaries(
         ColorPrimaries::BT709
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use v_frame::{chroma::ChromaSubsampling, frame::FrameBuilder};
+
+    use super::*;
+
+    #[test]
+    fn yuverror_fmt() {
+        let errors = &[
+            YuvError::SubsamplingMismatch,
+            YuvError::InvalidLumaWidth,
+            YuvError::InvalidLumaHeight,
+            YuvError::InvalidData,
+        ];
+
+        for err in errors {
+            let msg = format!("{err}");
+            // exact message is not important
+            assert!(!msg.is_empty());
+        }
+    }
+
+    fn make_simple_yuvconfig(bit_depth: u8, subsampling_x: u8, subsampling_y: u8) -> YuvConfig {
+        YuvConfig {
+            bit_depth,
+            subsampling_x,
+            subsampling_y,
+            full_range: false,
+            matrix_coefficients: MatrixCoefficients::BT709,
+            transfer_characteristics: TransferCharacteristic::BT1886,
+            color_primaries: ColorPrimaries::BT709,
+        }
+    }
+
+    #[test]
+    fn yuv_new_subsample_mismatch() {
+        let data: Frame<u8> = FrameBuilder::new(320, 240, ChromaSubsampling::Yuv444, 8)
+            .build()
+            .unwrap();
+
+        let cfg = make_simple_yuvconfig(8, 0, 1);
+
+        assert!(matches!(
+            Yuv::new(data, cfg),
+            Err(YuvError::SubsamplingMismatch)
+        ));
+    }
+
+    #[test]
+    fn yuv_new_no_monochrome() {
+        let data: Frame<u8> = FrameBuilder::new(320, 240, ChromaSubsampling::Monochrome, 8)
+            .build()
+            .unwrap();
+
+        let cfg = make_simple_yuvconfig(8, 0, 0);
+
+        assert!(matches!(
+            Yuv::new(data, cfg),
+            Err(YuvError::SubsamplingMismatch)
+        ));
+    }
+
+    #[test]
+    fn yuvconfig_fix_unspecified() {
+        use ColorPrimaries as CP;
+        use MatrixCoefficients as MC;
+        use TransferCharacteristic as TC;
+
+        let config = YuvConfig {
+            bit_depth: 8,
+            subsampling_x: 0,
+            subsampling_y: 0,
+            full_range: false,
+            matrix_coefficients: MC::Unspecified,
+            transfer_characteristics: TC::Unspecified,
+            color_primaries: CP::Unspecified,
+        };
+
+        let fixed = config.fix_unspecified_data(640, 480);
+        assert_ne!(fixed.matrix_coefficients, MC::Unspecified);
+        assert_ne!(fixed.transfer_characteristics, TC::Unspecified);
+        assert_ne!(fixed.color_primaries, CP::Unspecified);
+
+        let fixed = config.fix_unspecified_data(1920, 1080);
+        assert_ne!(fixed.matrix_coefficients, MC::Unspecified);
+        assert_ne!(fixed.transfer_characteristics, TC::Unspecified);
+        assert_ne!(fixed.color_primaries, CP::Unspecified);
+
+        let fixed = config.fix_unspecified_data(3840, 2160);
+        assert_ne!(fixed.matrix_coefficients, MC::Unspecified);
+        assert_ne!(fixed.transfer_characteristics, TC::Unspecified);
+        assert_ne!(fixed.color_primaries, CP::Unspecified);
+    }
+}

--- a/yuvxyb/src/yuv.rs
+++ b/yuvxyb/src/yuv.rs
@@ -1,5 +1,5 @@
+use std::fmt;
 use std::mem::size_of;
-use std::{fmt, num::NonZeroUsize};
 
 use av_data::pixel::{ColorPrimaries, MatrixCoefficients, TransferCharacteristic};
 use v_frame::{frame::Frame, pixel::Pixel, plane::Plane};
@@ -103,10 +103,6 @@ impl<T: Pixel> Yuv<T> {
     ///   frame data
     /// - If `data` contains values which are not valid for the specified bit
     ///   depth (note: out-of-range values for limited range are allowed)
-    // Clippy complains about T::to_u16 maybe panicking, but it can be assumed
-    // to never panic because the Pixel trait is only implemented by u8 and
-    // u16, both of which will successfully return a u16 from to_u16.
-    #[allow(clippy::missing_panics_doc)]
     pub fn new(data: Frame<T>, config: YuvConfig) -> Result<Self, YuvError> {
         let ss_ratio = data.subsampling.subsample_ratio();
         match ss_ratio {
@@ -155,16 +151,18 @@ impl<T: Pixel> Yuv<T> {
         &self.data
     }
 
+    /// Guaranteed to be non-zero.
     #[must_use]
     #[inline]
-    pub fn width(&self) -> NonZeroUsize {
-        NonZeroUsize::new(self.data.y_plane.width()).expect("is non-zero")
+    pub fn width(&self) -> usize {
+        self.data.y_plane.width()
     }
 
+    /// Guaranteed to be non-zero.
     #[must_use]
     #[inline]
-    pub fn height(&self) -> NonZeroUsize {
-        NonZeroUsize::new(self.data.y_plane.height()).expect("is non-zero")
+    pub fn height(&self) -> usize {
+        self.data.y_plane.height()
     }
 
     #[must_use]
@@ -243,7 +241,7 @@ impl<T: Pixel> TryFrom<(&Rgb, YuvConfig)> for Yuv<T> {
     fn try_from(other: (&Rgb, YuvConfig)) -> Result<Self, Self::Error> {
         let rgb = other.0;
         let config = other.1;
-        rgb_to_yuv(rgb.data(), rgb.width().get(), rgb.height().get(), config)
+        rgb_to_yuv(rgb.data(), rgb.width(), rgb.height(), config)
     }
 }
 

--- a/yuvxyb/src/yuv.rs
+++ b/yuvxyb/src/yuv.rs
@@ -125,19 +125,16 @@ impl<T: Pixel> Yuv<T> {
 
         let width = data.y_plane.width();
         let height = data.y_plane.height();
-        if !width.get().is_multiple_of(1 << config.subsampling_x) {
+        if !width.is_multiple_of(1 << config.subsampling_x) {
             return Err(YuvError::InvalidLumaWidth);
         }
-        if !height.get().is_multiple_of(1 << config.subsampling_y) {
+        if !height.is_multiple_of(1 << config.subsampling_y) {
             return Err(YuvError::InvalidLumaHeight);
         }
         if size_of::<T>() == 2 && config.bit_depth < 16 {
             let max_value = u16::MAX >> (16 - config.bit_depth);
-            let plane_data_invalid = |plane: &Plane<T>| -> bool {
-                plane
-                    .pixels()
-                    .any(|pix| pix.to_u16().expect("This is a u16") > max_value)
-            };
+            let plane_data_invalid =
+                |plane: &Plane<T>| plane.pixels().any(|pix| pix.into() > max_value);
             if plane_data_invalid(&data.y_plane)
                 || data.u_plane.as_ref().is_some_and(plane_data_invalid)
                 || data.v_plane.as_ref().is_some_and(plane_data_invalid)
@@ -161,13 +158,13 @@ impl<T: Pixel> Yuv<T> {
     #[must_use]
     #[inline]
     pub fn width(&self) -> NonZeroUsize {
-        self.data.y_plane.width()
+        NonZeroUsize::new(self.data.y_plane.width()).expect("is non-zero")
     }
 
     #[must_use]
     #[inline]
     pub fn height(&self) -> NonZeroUsize {
-        self.data.y_plane.height()
+        NonZeroUsize::new(self.data.y_plane.height()).expect("is non-zero")
     }
 
     #[must_use]
@@ -178,11 +175,7 @@ impl<T: Pixel> Yuv<T> {
 }
 
 impl YuvConfig {
-    pub(crate) fn fix_unspecified_data(
-        mut self,
-        width: NonZeroUsize,
-        height: NonZeroUsize,
-    ) -> Self {
+    pub(crate) fn fix_unspecified_data(mut self, width: usize, height: usize) -> Self {
         if self.matrix_coefficients == MatrixCoefficients::Unspecified {
             self.matrix_coefficients = guess_matrix_coefficients(width, height);
             log::warn!(
@@ -250,18 +243,15 @@ impl<T: Pixel> TryFrom<(&Rgb, YuvConfig)> for Yuv<T> {
     fn try_from(other: (&Rgb, YuvConfig)) -> Result<Self, Self::Error> {
         let rgb = other.0;
         let config = other.1;
-        rgb_to_yuv(rgb.data(), rgb.width(), rgb.height(), config)
+        rgb_to_yuv(rgb.data(), rgb.width().get(), rgb.height().get(), config)
     }
 }
 
 // Heuristic taken from mpv
-const fn guess_matrix_coefficients(
-    width: NonZeroUsize,
-    height: NonZeroUsize,
-) -> MatrixCoefficients {
-    if width.get() >= 1280 || height.get() > 576 {
+const fn guess_matrix_coefficients(width: usize, height: usize) -> MatrixCoefficients {
+    if width >= 1280 || height > 576 {
         MatrixCoefficients::BT709
-    } else if height.get() == 576 {
+    } else if height == 576 {
         MatrixCoefficients::BT470BG
     } else {
         MatrixCoefficients::ST170M
@@ -271,18 +261,18 @@ const fn guess_matrix_coefficients(
 // Heuristic taken from mpv
 fn guess_color_primaries(
     matrix: MatrixCoefficients,
-    width: NonZeroUsize,
-    height: NonZeroUsize,
+    width: usize,
+    height: usize,
 ) -> ColorPrimaries {
     if matrix == MatrixCoefficients::BT2020NonConstantLuminance
         || matrix == MatrixCoefficients::BT2020ConstantLuminance
     {
         ColorPrimaries::BT2020
-    } else if matrix == MatrixCoefficients::BT709 || width.get() >= 1280 || height.get() > 576 {
+    } else if matrix == MatrixCoefficients::BT709 || width >= 1280 || height > 576 {
         ColorPrimaries::BT709
-    } else if height.get() == 576 {
+    } else if height == 576 {
         ColorPrimaries::BT470BG
-    } else if height.get() == 480 || height.get() == 488 {
+    } else if height == 480 || height == 488 {
         ColorPrimaries::ST170M
     } else {
         ColorPrimaries::BT709

--- a/yuvxyb/src/yuv_rgb/color.rs
+++ b/yuvxyb/src/yuv_rgb/color.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroUsize;
-
 use av_data::pixel::{ColorPrimaries, MatrixCoefficients};
 
 use super::{ycbcr_to_ypbpr, ypbpr_to_ycbcr};
@@ -187,8 +185,8 @@ pub fn yuv_to_rgb<T: Pixel>(input: &Yuv<T>) -> Result<Vec<[f32; 3]>, ConversionE
 /// - If the `YuvConfig` would produce an invalid image
 pub fn rgb_to_yuv<T: Pixel>(
     input: &[[f32; 3]],
-    width: NonZeroUsize,
-    height: NonZeroUsize,
+    width: usize,
+    height: usize,
     config: YuvConfig,
 ) -> Result<Yuv<T>, ConversionError> {
     let transform = get_rgb_to_yuv_matrix(config)?;

--- a/yuvxyb/src/yuv_rgb/mod.rs
+++ b/yuvxyb/src/yuv_rgb/mod.rs
@@ -13,8 +13,6 @@ mod transfer;
 #[cfg(test)]
 mod tests;
 
-use std::num::{NonZeroU8, NonZeroUsize};
-
 use num_traits::clamp;
 use v_frame::chroma::ChromaSubsampling;
 use v_frame::frame::FrameBuilder;
@@ -44,12 +42,15 @@ fn ycbcr_to_ypbpr<T: Pixel>(input: &Yuv<T>) -> Vec<[f32; 3]> {
         .v_plane
         .as_ref()
         .expect("monochrome currently unsupported");
-    let y_stride = y_plane.geometry().stride.get();
-    let u_stride = u_plane.geometry().stride.get();
-    let v_stride = v_plane.geometry().stride.get();
-    let y_origin = &y_plane.data()[y_plane.data_origin()..];
-    let u_origin = &u_plane.data()[u_plane.data_origin()..];
-    let v_origin = &v_plane.data()[v_plane.data_origin()..];
+    let y_stride = y_plane.geometry().stride();
+    let u_stride = u_plane.geometry().stride();
+    let v_stride = v_plane.geometry().stride();
+    let y_origin = y_plane.geometry().data_origin();
+    let u_origin = u_plane.geometry().data_origin();
+    let v_origin = v_plane.geometry().data_origin();
+    let y_origin = &y_plane.data()[y_origin..];
+    let u_origin = &u_plane.data()[u_origin..];
+    let v_origin = &v_plane.data()[v_origin..];
     let mut output = vec![[0.0, 0.0, 0.0]; w * h];
     for y in 0..h {
         for x in 0..w {
@@ -73,8 +74,8 @@ fn ycbcr_to_ypbpr<T: Pixel>(input: &Yuv<T>) -> Vec<[f32; 3]> {
 #[allow(clippy::too_many_lines)]
 fn ypbpr_to_ycbcr<T: Pixel>(
     input: &[[f32; 3]],
-    width: NonZeroUsize,
-    height: NonZeroUsize,
+    width: usize,
+    height: usize,
     config: YuvConfig,
 ) -> Yuv<T> {
     let ss_x = config.subsampling_x;
@@ -91,14 +92,9 @@ fn ypbpr_to_ycbcr<T: Pixel>(
         0 => ChromaSubsampling::Yuv444,
         _ => unreachable!(),
     };
-    let mut output = FrameBuilder::new(
-        width,
-        height,
-        chroma,
-        NonZeroU8::new(bd).expect("should not be zero"),
-    )
-    .build()
-    .expect("should not fail");
+    let mut output = FrameBuilder::new(width, height, chroma, bd)
+        .build()
+        .expect("should not fail");
 
     // We setup the plane origins as mutable slices outside the loop
     // because `data_origin_mut` is _not_ just a simple array index,
@@ -106,19 +102,19 @@ fn ypbpr_to_ycbcr<T: Pixel>(
     let y_plane = &mut output.y_plane;
     let u_plane = output.u_plane.as_mut().expect("has 3 planes");
     let v_plane = output.v_plane.as_mut().expect("has 3 planes");
-    let y_stride = y_plane.geometry().stride.get();
-    let u_stride = u_plane.geometry().stride.get();
-    let v_stride = v_plane.geometry().stride.get();
-    let y_origin = y_plane.data_origin();
-    let u_origin = u_plane.data_origin();
-    let v_origin = v_plane.data_origin();
+    let y_stride = y_plane.geometry().stride();
+    let u_stride = u_plane.geometry().stride();
+    let v_stride = v_plane.geometry().stride();
+    let y_origin = y_plane.geometry().data_origin();
+    let u_origin = u_plane.geometry().data_origin();
+    let v_origin = v_plane.geometry().data_origin();
     let y_origin = &mut y_plane.data_mut()[y_origin..];
     let u_origin = &mut u_plane.data_mut()[u_origin..];
     let v_origin = &mut v_plane.data_mut()[v_origin..];
     let mut last_uv_pos = usize::MAX;
-    for y in 0..height.get() {
-        for x in 0..width.get() {
-            let input_pos = y * width.get() + x;
+    for y in 0..height {
+        for x in 0..width {
+            let input_pos = y * width + x;
             let y_pos = y * y_stride + x;
             let u_pos = (y >> ss_y) * u_stride + (x >> ss_x);
             let v_pos = (y >> ss_y) * v_stride + (x >> ss_x);

--- a/yuvxyb/src/yuv_rgb/mod.rs
+++ b/yuvxyb/src/yuv_rgb/mod.rs
@@ -21,8 +21,8 @@ pub use self::transfer::TransferFunction;
 use crate::{Pixel, Yuv, YuvConfig};
 
 fn ycbcr_to_ypbpr<T: Pixel>(input: &Yuv<T>) -> Vec<[f32; 3]> {
-    let w = input.width().get();
-    let h = input.height().get();
+    let w = input.width();
+    let h = input.height();
     let ss_x = input.config().subsampling_x;
     let ss_y = input.config().subsampling_y;
     let bd = input.config().bit_depth;

--- a/yuvxyb/src/yuv_rgb/mod.rs
+++ b/yuvxyb/src/yuv_rgb/mod.rs
@@ -13,8 +13,11 @@ mod transfer;
 #[cfg(test)]
 mod tests;
 
+use std::num::NonZeroU8;
+
 use v_frame::chroma::ChromaSubsampling;
-use v_frame::frame::FrameBuilder;
+use v_frame::frame::Frame;
+use v_frame::plane::{Plane, PlaneGeometry};
 
 pub use self::color::{rgb_to_yuv, transform_primaries, yuv_to_rgb};
 pub use self::transfer::TransferFunction;
@@ -91,16 +94,19 @@ fn ypbpr_to_ycbcr<T: Pixel>(
         0 => ChromaSubsampling::Yuv444,
         _ => unreachable!(),
     };
-    let mut output = FrameBuilder::new(width, height, chroma, bd)
-        .build()
-        .expect("should not fail");
+
+    let y_geometry = PlaneGeometry::unpadded(width, height, 1, 1).expect("can construct geometry");
+    let mut y_plane = Plane::new_uninit(y_geometry);
+    let chroma_geometry = y_geometry
+        .for_subsampling(chroma)
+        .expect("can subsample")
+        .expect("has chroma planes");
+    let mut u_plane = Plane::new_uninit(chroma_geometry);
+    let mut v_plane = Plane::new_uninit(chroma_geometry);
 
     // We setup the plane origins as mutable slices outside the loop
     // because `data_origin_mut` is _not_ just a simple array index,
     // so it would optimize poorly if called during each loop iteration.
-    let y_plane = &mut output.y_plane;
-    let u_plane = output.u_plane.as_mut().expect("has 3 planes");
-    let v_plane = output.v_plane.as_mut().expect("has 3 planes");
     let y_stride = y_plane.geometry().stride();
     let u_stride = u_plane.geometry().stride();
     let v_stride = v_plane.geometry().stride();
@@ -120,21 +126,46 @@ fn ypbpr_to_ycbcr<T: Pixel>(
             // SAFETY: The bounds of the YUV data are validated when we construct it.
             unsafe {
                 let pix = input.get_unchecked(input_pos);
-                *y_origin.get_unchecked_mut(y_pos) =
-                    from_f32_luma(pix[0], luma_scale, luma_offset, bd);
+                y_origin.get_unchecked_mut(y_pos).write(from_f32_luma(
+                    pix[0],
+                    luma_scale,
+                    luma_offset,
+                    bd,
+                ));
                 if u_pos != last_uv_pos {
                     // Small optimization to avoid doing unnecessary calculations and writes
                     // We can track this from just `u_pos`. We have `v_pos` separate for indexing
                     // on the off chance that the two planes have different strides.
-                    *u_origin.get_unchecked_mut(u_pos) =
-                        from_f32_chroma(pix[1], chroma_scale, chroma_offset, bd, full_range);
-                    *v_origin.get_unchecked_mut(v_pos) =
-                        from_f32_chroma(pix[2], chroma_scale, chroma_offset, bd, full_range);
+                    u_origin.get_unchecked_mut(u_pos).write(from_f32_chroma(
+                        pix[1],
+                        chroma_scale,
+                        chroma_offset,
+                        bd,
+                        full_range,
+                    ));
+                    v_origin.get_unchecked_mut(v_pos).write(from_f32_chroma(
+                        pix[2],
+                        chroma_scale,
+                        chroma_offset,
+                        bd,
+                        full_range,
+                    ));
                     last_uv_pos = u_pos;
                 }
             }
         }
     }
+
+    // SAFETY: All values of all planes have been initialized in the loop above.
+    let output = unsafe {
+        Frame {
+            y_plane: y_plane.assume_init(),
+            u_plane: Some(u_plane.assume_init()),
+            v_plane: Some(v_plane.assume_init()),
+            subsampling: chroma,
+            bit_depth: NonZeroU8::new(bd).expect("nonzero bitdepth"),
+        }
+    };
 
     Yuv::new(output, config).unwrap()
 }

--- a/yuvxyb/src/yuv_rgb/mod.rs
+++ b/yuvxyb/src/yuv_rgb/mod.rs
@@ -13,7 +13,6 @@ mod transfer;
 #[cfg(test)]
 mod tests;
 
-use num_traits::clamp;
 use v_frame::chroma::ChromaSubsampling;
 use v_frame::frame::FrameBuilder;
 
@@ -141,61 +140,43 @@ fn ypbpr_to_ycbcr<T: Pixel>(
 }
 
 fn to_f32_luma<T: Pixel>(val: T, scale: f32, offset: f32) -> f32 {
-    // Converts to a float value in the range 0.0..=1.0
-    let val = val.to_f32().expect("can convert to f32");
-    clamp(val.mul_add(scale, offset), 0.0, 1.0)
+    let val = f32::from(val.into());
+    val.mul_add(scale, offset).clamp(0.0, 1.0)
 }
 
 fn to_f32_chroma<T: Pixel>(val: T, scale: f32, offset: f32) -> f32 {
-    // Converts to a float value in the range -0.5..=0.5
-    let val = val.to_f32().expect("can convert to f32");
-    clamp(val.mul_add(scale, offset), -0.5, 0.5)
+    let val = f32::from(val.into());
+    val.mul_add(scale, offset).clamp(-0.5, 0.5)
 }
 
 fn from_f32_luma<T: Pixel>(val: f32, scale: f32, offset: f32, bd: u8) -> T {
-    // Converts to a float value in the range 0.0..=1.0
-    match size_of::<T>() {
-        1 => T::from(clamp(
-            val.mul_add(scale, offset).round() as u16,
-            0,
-            ((1u32 << bd) - 1) as u16,
-        ) as u8)
-        .expect("T is u8"),
-        2 => T::from(clamp(
-            val.mul_add(scale, offset).round() as u16,
-            0,
-            ((1u32 << bd) - 1) as u16,
-        ) as u16)
-        .expect("T is u16"),
-        _ => unreachable!(),
+    const { assert!(size_of::<T>() <= 2) };
+
+    let val = val.mul_add(scale, offset).round();
+    if size_of::<T>() == 1 {
+        T::from((val as u8).min(u8::MAX >> (8 - bd)))
+    } else {
+        T::try_from((val as u16).min(u16::MAX >> (16 - bd))).expect("T is u16")
     }
 }
 
 fn from_f32_chroma<T: Pixel>(val: f32, scale: f32, offset: f32, bd: u8, full_range: bool) -> T {
+    const { assert!(size_of::<T>() <= 2) };
+
     // Accounts for rounding issues
     if full_range && (val + 0.5).abs() < f32::EPSILON {
-        return match size_of::<T>() {
-            1 => T::from(0u8).expect("T is u8"),
-            2 => T::from(0u16).expect("T is u16"),
-            _ => unreachable!(),
+        return if size_of::<T>() == 1 {
+            T::from(0u8)
+        } else {
+            T::try_from(0u16).expect("T is u16")
         };
     }
 
-    // Converts from a float value in the range -0.5..=0.5
-    match size_of::<T>() {
-        1 => T::from(clamp(
-            val.mul_add(scale, offset).round() as u16,
-            0,
-            ((1u32 << bd) - 1) as u16,
-        ) as u8)
-        .expect("T is u8"),
-        2 => T::from(clamp(
-            val.mul_add(scale, offset).round() as u16,
-            0,
-            ((1u32 << bd) - 1) as u16,
-        ) as u16)
-        .expect("T is u16"),
-        _ => unreachable!(),
+    let val = val.mul_add(scale, offset).round();
+    if size_of::<T>() == 1 {
+        T::from((val as u8).min(u8::MAX >> (8 - bd)))
+    } else {
+        T::try_from((val as u16).min(u16::MAX >> (16 - bd))).expect("T is u16")
     }
 }
 

--- a/yuvxyb/src/yuv_rgb/tests.rs
+++ b/yuvxyb/src/yuv_rgb/tests.rs
@@ -1,5 +1,3 @@
-use std::num::{NonZeroU8, NonZeroUsize};
-
 use av_data::pixel::{ColorPrimaries, MatrixCoefficients, TransferCharacteristic};
 use num_traits::clamp;
 use v_frame::chroma::ChromaSubsampling;
@@ -30,12 +28,7 @@ fn linear_rgb_to_yuv<T: Pixel>(
 ) -> Result<Yuv<T>, ConversionError> {
     let data = transform_primaries(input, ColorPrimaries::BT709, config.color_primaries)?;
     let data = config.transfer_characteristics.to_gamma(data)?;
-    rgb_to_yuv(
-        &data,
-        NonZeroUsize::new(width).unwrap(),
-        NonZeroUsize::new(height).unwrap(),
-        config,
-    )
+    rgb_to_yuv(&data, width, height, config)
 }
 
 fn make_frame_from_pixels<T: Pixel>(
@@ -44,14 +37,10 @@ fn make_frame_from_pixels<T: Pixel>(
     height: usize,
     bit_depth: u8,
 ) -> Frame<T> {
-    let mut frame: Frame<T> = FrameBuilder::new(
-        NonZeroUsize::new(width).unwrap(),
-        NonZeroUsize::new(height).unwrap(),
-        ChromaSubsampling::Yuv444,
-        NonZeroU8::new(bit_depth).unwrap(),
-    )
-    .build()
-    .unwrap();
+    let mut frame: Frame<T> =
+        FrameBuilder::new(width, height, ChromaSubsampling::Yuv444, bit_depth)
+            .build()
+            .unwrap();
     frame
         .y_plane
         .copy_from_slice(&yuv_pixels.iter().map(|p| p.0).collect::<Vec<_>>())

--- a/yuvxyb/src/yuv_rgb/tests.rs
+++ b/yuvxyb/src/yuv_rgb/tests.rs
@@ -1,5 +1,4 @@
 use av_data::pixel::{ColorPrimaries, MatrixCoefficients, TransferCharacteristic};
-use num_traits::clamp;
 use v_frame::chroma::ChromaSubsampling;
 use v_frame::frame::{Frame, FrameBuilder};
 
@@ -133,7 +132,7 @@ fn to_f32_luma_limited() {
         );
         let (scale, offset) = get_scale_offset::<false>(bd, full_range, false);
         let result: u8 = from_f32_luma(result, scale, offset, bd);
-        let expected = clamp(input, 16, 235);
+        let expected = input.clamp(16, 235);
         assert!(
             expected == result,
             "Result {result} differed from expected {input}"
@@ -214,7 +213,7 @@ fn to_f32_chroma_limited() {
         );
         let (scale, offset) = get_scale_offset::<false>(bd, full_range, true);
         let result: u8 = from_f32_chroma(result, scale, offset, bd, full_range);
-        let expected = clamp(input, 16, 240);
+        let expected = input.clamp(16, 240);
         assert!(
             expected == result,
             "Result {result} differed from expected {input}"
@@ -317,7 +316,7 @@ fn to_f32_luma_limited_10b() {
         );
         let (scale, offset) = get_scale_offset::<false>(bd, full_range, false);
         let result: u16 = from_f32_luma(result, scale, offset, bd);
-        let expected = clamp(input, 16 << 2u8, 235 << 2u8);
+        let expected = input.clamp(16 << 2u8, 235 << 2u8);
         assert!(
             expected == result,
             "Result {result} differed from expected {input}"
@@ -420,7 +419,7 @@ fn to_f32_chroma_limited_10b() {
         );
         let (scale, offset) = get_scale_offset::<false>(bd, full_range, true);
         let result: u16 = from_f32_chroma(result, scale, offset, bd, full_range);
-        let expected = clamp(input, 16 << 2u8, 240 << 2u8);
+        let expected = input.clamp(16 << 2u8, 240 << 2u8);
         assert!(
             expected == result,
             "Result {result} differed from expected {input}"


### PR DESCRIPTION
Highly recommend reviewing commit-by-commit.

A lot of simple changes (removing `.get()` etc) but some more meaningful ones. Small bonus: We can now use uninitialized memory in a safe and idiomatic way in `ypbpr_to_ycbcr`, gaining me a ~5% speedup in the new bench.
